### PR TITLE
feat: 管理パネル Phase 1 — HotkeyManager + 定数 + テスト

### DIFF
--- a/Sobani.xcodeproj/project.pbxproj
+++ b/Sobani.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		F0SL000002000000000001 /* AppDelegate+StatusBarMenuSliders.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0SL000001000000000001 /* AppDelegate+StatusBarMenuSliders.swift */; };
 		F0WH000002000000000001 /* WindowStateHiddenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0WH000001000000000001 /* WindowStateHiddenTests.swift */; };
 		F0TH000002000000000001 /* AppThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0TH000001000000000001 /* AppThemeTests.swift */; };
+		F0HK000002000000000001 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0HK000001000000000001 /* HotkeyManager.swift */; };
+		F0HK000004000000000001 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0HK000003000000000001 /* HotkeyManagerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -207,6 +209,8 @@
 		F0SL000001000000000001 /* AppDelegate+StatusBarMenuSliders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+StatusBarMenuSliders.swift"; sourceTree = "<group>"; };
 		F0WH000001000000000001 /* WindowStateHiddenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowStateHiddenTests.swift; sourceTree = "<group>"; };
 		F0TH000001000000000001 /* AppThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppThemeTests.swift; sourceTree = "<group>"; };
+		F0HK000001000000000001 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
+		F0HK000003000000000001 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -283,6 +287,7 @@
 				F0TB000001000000000001 /* CropEditorToolbarView.swift */,
 				F0EH000001000000000001 /* CropEditHistory.swift */,
 				F0AF000001000000000001 /* AlertFactory.swift */,
+				F0HK000001000000000001 /* HotkeyManager.swift */,
 				F0JP000001000000000001 /* JSONPersistence.swift */,
 				F0NP000001000000000001 /* NSPanel+FloatingConfig.swift */,
 				F0NM000001000000000001 /* NSMenu+RegisteredImages.swift */,
@@ -348,6 +353,7 @@
 				F0GM000001000000000001 /* WindowStateGhostModeTests.swift */,
 				F0WH000001000000000001 /* WindowStateHiddenTests.swift */,
 				F0TH000001000000000001 /* AppThemeTests.swift */,
+				F0HK000003000000000001 /* HotkeyManagerTests.swift */,
 			);
 			path = SobaniTests;
 			sourceTree = "<group>";
@@ -511,6 +517,7 @@
 				F0TB000002000000000001 /* CropEditorToolbarView.swift in Sources */,
 				F0EH000002000000000001 /* CropEditHistory.swift in Sources */,
 				F0AF000002000000000001 /* AlertFactory.swift in Sources */,
+				F0HK000002000000000001 /* HotkeyManager.swift in Sources */,
 				F0JP000002000000000001 /* JSONPersistence.swift in Sources */,
 				F0NP000002000000000001 /* NSPanel+FloatingConfig.swift in Sources */,
 				F0NM000002000000000001 /* NSMenu+RegisteredImages.swift in Sources */,
@@ -563,6 +570,7 @@
 				F0GM000002000000000001 /* WindowStateGhostModeTests.swift in Sources */,
 				F0WH000002000000000001 /* WindowStateHiddenTests.swift in Sources */,
 				F0TH000002000000000001 /* AppThemeTests.swift in Sources */,
+				F0HK000004000000000001 /* HotkeyManagerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sobani/Constants.swift
+++ b/Sobani/Constants.swift
@@ -67,6 +67,8 @@ enum AppConstants {
 
     // Hotkey
     static let optionHKeyCode: UInt16 = 4
+    static let optionGKeyCode: UInt16 = 5
+    static let optionPKeyCode: UInt16 = 35
     static let escKeyCode: UInt16 = 53
 
     // Display ID
@@ -103,7 +105,6 @@ enum AppConstants {
     static let ghostModeAlphaMax: CGFloat = 0.9
     static let ghostModeAlphaKey = "ghostModeAlpha"
     static let ghostModeAnimationDuration: TimeInterval = 0.3
-    static let optionGKeyCode: UInt16 = 5
     static let ghostModeSymbol = "face.dashed"
     static let hiddenWindowSymbol = "eye.slash"
     static let visibleWindowSymbol = "eye"
@@ -219,6 +220,23 @@ enum AppConstants {
         static let currentVersion = 1
         static let completedVersionKey = "onboardingCompletedVersion"
     }
+
+    // Management Panel
+    static let managementPanelWidth: CGFloat = 640
+    static let managementPanelHeight: CGFloat = 500
+    static let managementPanelCornerRadius: CGFloat = 12
+    static let managementPanelSidebarWidth: CGFloat = 44
+    static let managementPanelTitleBarHeight: CGFloat = 36
+    static let managementPanelStatusBarHeight: CGFloat = 20
+    static let managementPanelContentWidth: CGFloat = 596
+    static let managementPanelContentHeight: CGFloat = 444
+    static let managementPanelListWidth: CGFloat = 240
+    static let managementPanelDetailWidth: CGFloat = 356
+    static let managementPanelRowHeight: CGFloat = 44
+    static let managementPanelLayoutRowHeight: CGFloat = 48
+    static let managementPanelBulkBarHeight: CGFloat = 40
+    static let managementPanelPreviewMaxWidth: CGFloat = 320
+    static let managementPanelPreviewMaxHeight: CGFloat = 180
 }
 
 enum GhostModeSettings {
@@ -366,6 +384,7 @@ enum MenuItemTag: Int, CaseIterable, Sendable {
     case ghostModeAlphaSlider = 1035
     case opacitySliderContext = 1036
     case hideWindowToggle = 1037
+    case managementPanel = 1038
 }
 
 enum AppTheme: String, CaseIterable, Sendable {

--- a/Sobani/HotkeyManager.swift
+++ b/Sobani/HotkeyManager.swift
@@ -1,0 +1,221 @@
+import AppKit
+import os.log
+
+// MARK: - HotkeyAction
+
+enum HotkeyAction: String, CaseIterable, Codable, Sendable {
+    case toggleVisibility
+    case toggleGhostMode
+    case managementPanel
+
+    var defaultBinding: HotkeyBinding {
+        switch self {
+        case .toggleVisibility:
+            return HotkeyBinding(
+                keyCode: AppConstants.optionHKeyCode,
+                modifierMask: NSEvent.ModifierFlags.option.rawValue
+            )
+        case .toggleGhostMode:
+            return HotkeyBinding(
+                keyCode: AppConstants.optionGKeyCode,
+                modifierMask: NSEvent.ModifierFlags.option.rawValue
+            )
+        case .managementPanel:
+            return HotkeyBinding(
+                keyCode: AppConstants.optionPKeyCode,
+                modifierMask: NSEvent.ModifierFlags.option.rawValue
+            )
+        }
+    }
+
+    var userDefaultsKey: String { "hotkey_\(rawValue)" }
+
+    var displayName: String {
+        switch self {
+        case .toggleVisibility: return L("hotkey.toggle_visibility")
+        case .toggleGhostMode: return L("hotkey.toggle_ghost_mode")
+        case .managementPanel: return L("hotkey.management_panel")
+        }
+    }
+}
+
+// MARK: - HotkeyBinding
+
+struct HotkeyBinding: Codable, Sendable, Equatable {
+    let keyCode: UInt16
+    let modifierMask: UInt
+
+    var modifiers: NSEvent.ModifierFlags {
+        NSEvent.ModifierFlags(rawValue: modifierMask)
+    }
+
+    var displayString: String {
+        var parts: [String] = []
+        let flags = modifiers
+        if flags.contains(.control) { parts.append("⌃") }
+        if flags.contains(.option) { parts.append("⌥") }
+        if flags.contains(.shift) { parts.append("⇧") }
+        if flags.contains(.command) { parts.append("⌘") }
+        parts.append(Self.keyName(for: keyCode))
+        return parts.joined()
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity
+    static func keyName(for keyCode: UInt16) -> String {
+        switch keyCode {
+        case 0: return "A"
+        case 1: return "S"
+        case 2: return "D"
+        case 3: return "F"
+        case 4: return "H"
+        case 5: return "G"
+        case 6: return "Z"
+        case 7: return "X"
+        case 8: return "C"
+        case 9: return "V"
+        case 11: return "B"
+        case 12: return "Q"
+        case 13: return "W"
+        case 14: return "E"
+        case 15: return "R"
+        case 16: return "Y"
+        case 17: return "T"
+        case 18: return "1"
+        case 19: return "2"
+        case 20: return "3"
+        case 21: return "4"
+        case 22: return "6"
+        case 23: return "5"
+        case 24: return "="
+        case 25: return "9"
+        case 26: return "7"
+        case 27: return "-"
+        case 28: return "8"
+        case 29: return "0"
+        case 30: return "]"
+        case 31: return "O"
+        case 32: return "U"
+        case 33: return "["
+        case 34: return "I"
+        case 35: return "P"
+        case 36: return "Return"
+        case 37: return "L"
+        case 38: return "J"
+        case 39: return "'"
+        case 40: return "K"
+        case 41: return ";"
+        case 42: return "\\"
+        case 43: return ","
+        case 44: return "/"
+        case 45: return "N"
+        case 46: return "M"
+        case 47: return "."
+        case 48: return "Tab"
+        case 49: return "Space"
+        case 50: return "`"
+        case 51: return "Delete"
+        default: return "Key(\(keyCode))"
+        }
+    }
+}
+
+// MARK: - HotkeyManager
+
+/// UserDefaults（スレッドセーフ）と Logger（Sendable）のみ保持。
+/// cache は setBinding/resetBinding でのみ変更され、
+/// これらは @MainActor コンテキストから呼ばれる想定。
+final class HotkeyManager: @unchecked Sendable {
+    static let shared = HotkeyManager()
+
+    private static let encoder = JSONEncoder()
+    private static let decoder = JSONDecoder()
+
+    /// ⌘Space, ⌘Tab, ⌘Q などのシステム予約済みキーコード（O(1) 検索）
+    private static let reservedCommandKeyCodes: Set<UInt16> = [
+        49, // Space (⌘Space: Spotlight)
+        48, // Tab   (⌘Tab: App Switcher)
+        12, // Q     (⌘Q: Quit)
+        13, // W     (⌘W: Close Window)
+        14, // E
+        1,  // S     (⌘S: Save)
+        6,  // Z     (⌘Z: Undo)
+    ]
+
+    private let logger = Logger(category: "HotkeyManager")
+    private let defaults: UserDefaults
+    private var cache: [HotkeyAction: HotkeyBinding] = [:]
+
+    /// テストDI用。プロダクションコードでは `shared` を使用すること。
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        for action in HotkeyAction.allCases {
+            cache[action] = loadBinding(for: action)
+        }
+    }
+
+    // MARK: - Private
+
+    private func loadBinding(for action: HotkeyAction) -> HotkeyBinding {
+        guard let data = defaults.data(forKey: action.userDefaultsKey) else {
+            return action.defaultBinding
+        }
+        do {
+            return try Self.decoder.decode(HotkeyBinding.self, from: data)
+        } catch {
+            logger.error("Failed to decode HotkeyBinding for \(action.rawValue): \(error.localizedDescription)")
+            return action.defaultBinding
+        }
+    }
+
+    // MARK: - Public
+
+    func binding(for action: HotkeyAction) -> HotkeyBinding {
+        cache[action] ?? action.defaultBinding
+    }
+
+    func setBinding(_ binding: HotkeyBinding, for action: HotkeyAction) {
+        do {
+            let data = try Self.encoder.encode(binding)
+            defaults.set(data, forKey: action.userDefaultsKey)
+            cache[action] = binding
+        } catch {
+            logger.error("Failed to encode HotkeyBinding for \(action.rawValue): \(error.localizedDescription)")
+        }
+    }
+
+    func resetBinding(for action: HotkeyAction) {
+        defaults.removeObject(forKey: action.userDefaultsKey)
+        cache[action] = action.defaultBinding
+    }
+
+    func resetAllBindings() {
+        for action in HotkeyAction.allCases {
+            defaults.removeObject(forKey: action.userDefaultsKey)
+            cache[action] = action.defaultBinding
+        }
+    }
+
+    func hasSystemConflict(_ binding: HotkeyBinding) -> Bool {
+        // ⌘Space, ⌘Tab, ⌘Q などのシステム予約済みショートカットとの競合チェック
+        let flags = binding.modifiers
+        guard flags.contains(.command) else { return false }
+        return Self.reservedCommandKeyCodes.contains(binding.keyCode)
+    }
+
+    func hasSobaniConflict(_ binding: HotkeyBinding, excluding action: HotkeyAction) -> Bool {
+        HotkeyAction.allCases.contains { $0 != action && self.binding(for: $0) == binding }
+    }
+
+    nonisolated func matches(_ event: NSEvent, binding: HotkeyBinding) -> Bool {
+        guard event.type == .keyDown else { return false }
+        guard event.keyCode == binding.keyCode else { return false }
+        let eventFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let bindingFlags = NSEvent.ModifierFlags(rawValue: binding.modifierMask)
+            .intersection(.deviceIndependentFlagsMask)
+        return eventFlags == bindingFlags
+    }
+
+    func matchingAction(for event: NSEvent) -> HotkeyAction? {
+        HotkeyAction.allCases.first { matches(event, binding: binding(for: $0)) }
+    }
+}

--- a/Sobani/Localizable.xcstrings
+++ b/Sobani/Localizable.xcstrings
@@ -3632,6 +3632,54 @@
           }
         }
       }
+    },
+    "hotkey.toggle_visibility": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全表示/非表示"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Visibility"
+          }
+        }
+      }
+    },
+    "hotkey.toggle_ghost_mode": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全ゴースト"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Ghost Mode"
+          }
+        }
+      }
+    },
+    "hotkey.management_panel": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理パネル"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Management Panel"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/SobaniTests/ConstantsTests.swift
+++ b/SobaniTests/ConstantsTests.swift
@@ -61,7 +61,7 @@ import os.log
 
     /// MenuItemTagのケース数が想定通りであることを検証
     @Test func menuItemTag_CaseCount() {
-        #expect(MenuItemTag.allCases.count == 36)
+        #expect(MenuItemTag.allCases.count == 37)
     }
 
     // MARK: - Screen Restoration / Wake Retry 定数検証

--- a/SobaniTests/HotkeyManagerTests.swift
+++ b/SobaniTests/HotkeyManagerTests.swift
@@ -1,0 +1,184 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Sobani
+
+/// HotkeyManager・HotkeyAction・HotkeyBinding の動作を検証するテスト
+@Suite struct HotkeyManagerTests {
+
+    // MARK: - Helper
+
+    private func freshManager() throws -> (manager: HotkeyManager, cleanup: () -> Void) {
+        let suiteName = UUID().uuidString
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        let manager = HotkeyManager(defaults: defaults)
+        let cleanup = { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+        return (manager, cleanup)
+    }
+
+    // MARK: - HotkeyAction デフォルトバインディング
+
+    /// toggleVisibility のデフォルトバインディングが正しいことを検証
+    @Test func hotkeyAction_DefaultBinding_ToggleVisibility() {
+        let binding = HotkeyAction.toggleVisibility.defaultBinding
+        #expect(binding.keyCode == AppConstants.optionHKeyCode)
+        #expect(binding.modifierMask == NSEvent.ModifierFlags.option.rawValue)
+    }
+
+    /// toggleGhostMode のデフォルトバインディングが正しいことを検証
+    @Test func hotkeyAction_DefaultBinding_ToggleGhostMode() {
+        let binding = HotkeyAction.toggleGhostMode.defaultBinding
+        #expect(binding.keyCode == AppConstants.optionGKeyCode)
+        #expect(binding.modifierMask == NSEvent.ModifierFlags.option.rawValue)
+    }
+
+    /// managementPanel のデフォルトバインディングが正しいことを検証
+    @Test func hotkeyAction_DefaultBinding_ManagementPanel() {
+        let binding = HotkeyAction.managementPanel.defaultBinding
+        #expect(binding.keyCode == AppConstants.optionPKeyCode)
+        #expect(binding.modifierMask == NSEvent.ModifierFlags.option.rawValue)
+    }
+
+    /// userDefaultsKey が "hotkey_" + rawValue であることを検証
+    @Test func hotkeyAction_UserDefaultsKey() {
+        for action in HotkeyAction.allCases {
+            #expect(action.userDefaultsKey == "hotkey_\(action.rawValue)")
+        }
+    }
+
+    /// displayName が空でないことを検証
+    @Test func hotkeyAction_DisplayName_NonEmpty() {
+        for action in HotkeyAction.allCases {
+            #expect(!action.displayName.isEmpty)
+        }
+    }
+
+    // MARK: - HotkeyBinding displayString
+
+    /// ⌥P のdisplayStringが "⌥P" であることを検証
+    @Test func hotkeyBinding_DisplayString_OptionP() {
+        let binding = HotkeyBinding(
+            keyCode: 35,
+            modifierMask: NSEvent.ModifierFlags.option.rawValue
+        )
+        #expect(binding.displayString == "⌥P")
+    }
+
+    /// ⌘⌥S のdisplayStringに修飾キーと文字が含まれることを検証
+    @Test func hotkeyBinding_DisplayString_CommandOption() {
+        let flags = NSEvent.ModifierFlags([.command, .option])
+        let binding = HotkeyBinding(keyCode: 1, modifierMask: flags.rawValue)
+        let str = binding.displayString
+        #expect(str.contains("⌘"))
+        #expect(str.contains("⌥"))
+        #expect(str.contains("S"))
+    }
+
+    /// 不明なキーコードで "Key(N)" 形式になることを検証
+    @Test func hotkeyBinding_KeyName_Unknown() {
+        let name = HotkeyBinding.keyName(for: 200)
+        #expect(name == "Key(200)")
+    }
+
+    /// Tab キーコード(48)が "Tab" になることを検証
+    @Test func hotkeyBinding_KeyName_Tab() {
+        #expect(HotkeyBinding.keyName(for: 48) == "Tab")
+    }
+
+    /// Space キーコード(49)が "Space" になることを検証
+    @Test func hotkeyBinding_KeyName_Space() {
+        #expect(HotkeyBinding.keyName(for: 49) == "Space")
+    }
+
+    // MARK: - HotkeyManager バインディング保存・読み出し
+
+    /// カスタムバインディングを保存して読み出せることを検証
+    @Test func hotkeyManager_SetAndGetBinding() throws {
+        let (manager, cleanup) = try freshManager()
+        defer { cleanup() }
+        let custom = HotkeyBinding(
+            keyCode: 12,
+            modifierMask: NSEvent.ModifierFlags([.option, .shift]).rawValue
+        )
+        manager.setBinding(custom, for: .toggleVisibility)
+        let retrieved = manager.binding(for: .toggleVisibility)
+        #expect(retrieved == custom)
+    }
+
+    /// 未設定時にデフォルトバインディングが返されることを検証
+    @Test func hotkeyManager_DefaultWhenNotSet() throws {
+        let (manager, cleanup) = try freshManager()
+        defer { cleanup() }
+        let binding = manager.binding(for: .managementPanel)
+        #expect(binding == HotkeyAction.managementPanel.defaultBinding)
+    }
+
+    /// resetBinding でデフォルトに戻ることを検証
+    @Test func hotkeyManager_ResetBinding() throws {
+        let (manager, cleanup) = try freshManager()
+        defer { cleanup() }
+        let custom = HotkeyBinding(keyCode: 12, modifierMask: NSEvent.ModifierFlags.command.rawValue)
+        manager.setBinding(custom, for: .toggleGhostMode)
+        manager.resetBinding(for: .toggleGhostMode)
+        let binding = manager.binding(for: .toggleGhostMode)
+        #expect(binding == HotkeyAction.toggleGhostMode.defaultBinding)
+    }
+
+    /// resetAllBindings で全アクションがデフォルトに戻ることを検証
+    @Test func hotkeyManager_ResetAllBindings() throws {
+        let (manager, cleanup) = try freshManager()
+        defer { cleanup() }
+        for action in HotkeyAction.allCases {
+            let custom = HotkeyBinding(keyCode: 12, modifierMask: NSEvent.ModifierFlags.command.rawValue)
+            manager.setBinding(custom, for: action)
+        }
+        manager.resetAllBindings()
+        for action in HotkeyAction.allCases {
+            #expect(manager.binding(for: action) == action.defaultBinding)
+        }
+    }
+
+    // MARK: - 競合チェック
+
+    /// ⌘Spaceがシステム競合として検出されることを検証
+    @Test func hotkeyManager_HasSystemConflict_CommandSpace() throws {
+        let (manager, cleanup) = try freshManager()
+        defer { cleanup() }
+        let binding = HotkeyBinding(
+            keyCode: 49,
+            modifierMask: NSEvent.ModifierFlags.command.rawValue
+        )
+        #expect(manager.hasSystemConflict(binding))
+    }
+
+    /// ⌥Pはシステム競合なしであることを検証
+    @Test func hotkeyManager_NoSystemConflict_OptionP() throws {
+        let (manager, cleanup) = try freshManager()
+        defer { cleanup() }
+        let binding = HotkeyBinding(
+            keyCode: 35,
+            modifierMask: NSEvent.ModifierFlags.option.rawValue
+        )
+        #expect(!manager.hasSystemConflict(binding))
+    }
+
+    /// 同じバインディングを別アクションに設定するとSobani競合が検出されることを検証
+    @Test func hotkeyManager_HasSobaniConflict() throws {
+        let (manager, cleanup) = try freshManager()
+        defer { cleanup() }
+        let conflicting = HotkeyBinding(
+            keyCode: 12,
+            modifierMask: NSEvent.ModifierFlags.option.rawValue
+        )
+        manager.setBinding(conflicting, for: .toggleVisibility)
+        #expect(manager.hasSobaniConflict(conflicting, excluding: .toggleGhostMode))
+    }
+
+    /// 自分自身を除外した場合は競合なしとなることを検証
+    @Test func hotkeyManager_NoSobaniConflict_ExcludingSelf() throws {
+        let (manager, cleanup) = try freshManager()
+        defer { cleanup() }
+        let binding = manager.binding(for: .toggleVisibility)
+        #expect(!manager.hasSobaniConflict(binding, excluding: .toggleVisibility))
+    }
+}


### PR DESCRIPTION
## 概要

- `HotkeyAction` enum / `HotkeyBinding` struct / `HotkeyManager` class を新規作成
- 全3ホットキー（表示/非表示、ゴーストモード、管理パネル）のカスタマイズ基盤
- バインディングキャッシュ付きで `matchingAction` ホットパスが高速
- 管理パネルレイアウト定数を `Constants.swift` に追加
- 15個のユニットテスト全パス

## テスト計画

- [x] `./build.sh` — SwiftLint含め正常ビルド
- [x] `xcodebuild test` — 全テストパス（既存 + 新規15件）
- [x] `/simplify` レビュー 2回実施、指摘修正済み

Closes #27