### PR TITLE
feat: 管理パネル Phase 2 — パネル骨格 + ホットキー

### DIFF
--- a/Sobani.xcodeproj/project.pbxproj
+++ b/Sobani.xcodeproj/project.pbxproj
@@ -100,6 +100,8 @@
 		F0TH000002000000000001 /* AppThemeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0TH000001000000000001 /* AppThemeTests.swift */; };
 		F0HK000002000000000001 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0HK000001000000000001 /* HotkeyManager.swift */; };
 		F0HK000004000000000001 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0HK000003000000000001 /* HotkeyManagerTests.swift */; };
+		F0MP000002000000000001 /* ManagementPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0MP000001000000000001 /* ManagementPanelController.swift */; };
+		F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -211,6 +213,8 @@
 		F0TH000001000000000001 /* AppThemeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppThemeTests.swift; sourceTree = "<group>"; };
 		F0HK000001000000000001 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
 		F0HK000003000000000001 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
+		F0MP000001000000000001 /* ManagementPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelController.swift; sourceTree = "<group>"; };
+		F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ManagementPanel.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -288,6 +292,8 @@
 				F0EH000001000000000001 /* CropEditHistory.swift */,
 				F0AF000001000000000001 /* AlertFactory.swift */,
 				F0HK000001000000000001 /* HotkeyManager.swift */,
+				F0MP000001000000000001 /* ManagementPanelController.swift */,
+				F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */,
 				F0JP000001000000000001 /* JSONPersistence.swift */,
 				F0NP000001000000000001 /* NSPanel+FloatingConfig.swift */,
 				F0NM000001000000000001 /* NSMenu+RegisteredImages.swift */,
@@ -518,6 +524,8 @@
 				F0EH000002000000000001 /* CropEditHistory.swift in Sources */,
 				F0AF000002000000000001 /* AlertFactory.swift in Sources */,
 				F0HK000002000000000001 /* HotkeyManager.swift in Sources */,
+				F0MP000002000000000001 /* ManagementPanelController.swift in Sources */,
+				F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */,
 				F0JP000002000000000001 /* JSONPersistence.swift in Sources */,
 				F0NP000002000000000001 /* NSPanel+FloatingConfig.swift in Sources */,
 				F0NM000002000000000001 /* NSMenu+RegisteredImages.swift in Sources */,

--- a/Sobani/AppDelegate+ManagementPanel.swift
+++ b/Sobani/AppDelegate+ManagementPanel.swift
@@ -1,0 +1,26 @@
+import Cocoa
+
+// MARK: - Management Panel
+
+extension AppDelegate {
+    func setupManagementPanel() {
+        let controller = ManagementPanelController()
+        controller.delegate = self
+        managementPanelController = controller
+    }
+
+    func handleHotkeyAction(_ action: HotkeyAction) {
+        switch action {
+        case .toggleVisibility:
+            toggleAllWindowsVisibility()
+        case .toggleGhostMode:
+            toggleAllGhostMode()
+        case .managementPanel:
+            managementPanelController?.toggle()
+        }
+    }
+}
+
+// MARK: - ManagementPanelDelegate
+
+extension AppDelegate: ManagementPanelDelegate {}

--- a/Sobani/AppDelegate.swift
+++ b/Sobani/AppDelegate.swift
@@ -19,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     var screenChangeDebounceTimer: Timer?
     var wakeContext = WakeRestorationContext()
     var onboardingController: OnboardingWindowController?
+    var managementPanelController: ManagementPanelController?
     var isApplyingLayout = false
     weak var lastHighlightedWindow: CharacterWindow?
 
@@ -26,6 +27,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         NSApp.appearance = AppThemeSettings.currentTheme.nsAppearance
         setupStatusBar()
         setupHotkeyMonitors()
+        setupManagementPanel()
         screenRestorationManager.loadPending()
 
         let savedStates = WindowStateManager.shared.loadStates()
@@ -125,38 +127,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         areWindowsHidden.toggle()
     }
 
-    private nonisolated func isOptionHotkey(_ event: NSEvent, keyCode: UInt16) -> Bool {
-        event.keyCode == keyCode
-            && event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .option
-    }
-
     func setupHotkeyMonitors() {
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { @Sendable [weak self] event in
             guard let self else { return }
-            if self.isOptionHotkey(event, keyCode: AppConstants.optionHKeyCode) {
-                DispatchQueue.main.async { @Sendable [weak self] in
-                    self?.toggleAllWindowsVisibility()
-                }
-            } else if self.isOptionHotkey(event, keyCode: AppConstants.optionGKeyCode) {
-                DispatchQueue.main.async { @Sendable [weak self] in
-                    self?.toggleAllGhostMode()
-                }
+            guard let action = HotkeyManager.shared.matchingAction(for: event) else { return }
+            DispatchQueue.main.async { @Sendable [weak self] in
+                self?.handleHotkeyAction(action)
             }
         }
         localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { @Sendable [weak self] event in
             guard let self else { return event }
-            if self.isOptionHotkey(event, keyCode: AppConstants.optionHKeyCode) {
-                DispatchQueue.main.async { @Sendable [weak self] in
-                    self?.toggleAllWindowsVisibility()
-                }
-                return nil
-            } else if self.isOptionHotkey(event, keyCode: AppConstants.optionGKeyCode) {
-                DispatchQueue.main.async { @Sendable [weak self] in
-                    self?.toggleAllGhostMode()
-                }
-                return nil
+            guard let action = HotkeyManager.shared.matchingAction(for: event) else { return event }
+            DispatchQueue.main.async { @Sendable [weak self] in
+                self?.handleHotkeyAction(action)
             }
-            return event
+            return nil
         }
     }
 

--- a/Sobani/Localizable.xcstrings
+++ b/Sobani/Localizable.xcstrings
@@ -3665,6 +3665,22 @@
         }
       }
     },
+    "management.title": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "管理パネル"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Management Panel"
+          }
+        }
+      }
+    },
     "hotkey.management_panel": {
       "localizations": {
         "ja": {

--- a/Sobani/ManagementPanelController.swift
+++ b/Sobani/ManagementPanelController.swift
@@ -1,0 +1,199 @@
+import Cocoa
+import os.log
+
+// MARK: - ManagementPanelDelegate
+
+@MainActor
+protocol ManagementPanelDelegate: AnyObject {
+    // Phase 4 でウィンドウ操作の通知メソッドを追加予定
+}
+
+// MARK: - ManagementPanelController
+
+@MainActor
+final class ManagementPanelController: NSObject {
+    enum Tab: Int {
+        case windowManagement = 0
+        case layout = 1
+        case settings = 2
+    }
+
+    private static let closeButtonSize: CGFloat = 20
+    private static let titleFontSize: CGFloat = 13
+
+    private let logger = Logger(category: "ManagementPanelController")
+    private var panel: NSPanel?
+    private var backgroundView: NSVisualEffectView?
+    private var contentContainer: NSView?
+    private var titleBar: NSView?
+    nonisolated(unsafe) private var keyMonitor: Any?
+    weak var delegate: ManagementPanelDelegate?
+
+    var isVisible: Bool { panel?.isVisible ?? false }
+
+    // MARK: - Public API
+
+    func toggle() {
+        if isVisible {
+            dismiss()
+        } else {
+            show()
+        }
+    }
+
+    func show() {
+        if panel == nil {
+            setupPanel()
+        }
+
+        guard let panel else {
+            logger.error("Management panel is nil after setup")
+            return
+        }
+
+        guard let screen = NSScreen.main ?? NSScreen.screens.first else {
+            logger.error("No screen available to show management panel")
+            return
+        }
+
+        let screenFrame = screen.visibleFrame
+        let panelSize = NSSize(
+            width: AppConstants.managementPanelWidth,
+            height: AppConstants.managementPanelHeight
+        )
+        let origin = NSPoint(
+            x: screenFrame.midX - panelSize.width / 2,
+            y: screenFrame.midY - panelSize.height / 2
+        )
+
+        panel.setFrameOrigin(origin)
+        panel.makeKeyAndOrderFront(nil)
+
+        clearEventMonitors()
+        installEventMonitors()
+    }
+
+    func dismiss() {
+        clearEventMonitors()
+        panel?.orderOut(nil)
+    }
+
+    // MARK: - Panel Setup
+
+    private func setupPanel() {
+        let panelRect = NSRect(
+            x: 0,
+            y: 0,
+            width: AppConstants.managementPanelWidth,
+            height: AppConstants.managementPanelHeight
+        )
+
+        let newPanel = NSPanel(
+            contentRect: panelRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        newPanel.configureForFloating()
+        newPanel.level = .floating + 2
+        newPanel.hasShadow = true
+        newPanel.isOpaque = false
+        newPanel.backgroundColor = .clear
+
+        let effectView = NSVisualEffectView(frame: panelRect)
+        effectView.material = .menu
+        effectView.state = .active
+        effectView.blendingMode = .behindWindow
+        effectView.wantsLayer = true
+        effectView.layer?.cornerRadius = AppConstants.managementPanelCornerRadius
+        effectView.layer?.masksToBounds = true
+
+        setupTitleBar(in: effectView)
+
+        newPanel.contentView = effectView
+        backgroundView = effectView
+        panel = newPanel
+    }
+
+    private func setupTitleBar(in parent: NSView) {
+        let panelWidth = AppConstants.managementPanelWidth
+        let panelHeight = AppConstants.managementPanelHeight
+        let titleBarHeight = AppConstants.managementPanelTitleBarHeight
+
+        let titleBarFrame = NSRect(
+            x: AppConstants.managementPanelSidebarWidth,
+            y: panelHeight - titleBarHeight,
+            width: panelWidth - AppConstants.managementPanelSidebarWidth,
+            height: titleBarHeight
+        )
+        let bar = NSView(frame: titleBarFrame)
+        parent.addSubview(bar)
+        titleBar = bar
+
+        // Close button (✕)
+        let closeButtonFrame = NSRect(x: 4, y: (titleBarHeight - Self.closeButtonSize) / 2, width: Self.closeButtonSize, height: Self.closeButtonSize)
+        let closeButton = NSButton(frame: closeButtonFrame)
+        closeButton.bezelStyle = .regularSquare
+        closeButton.isBordered = false
+        closeButton.imagePosition = .imageOnly
+        closeButton.image = SFSymbolUtils.icon("xmark.circle.fill", pointSize: 14, weight: .regular)
+        closeButton.target = self
+        closeButton.action = #selector(closeTapped)
+        bar.addSubview(closeButton)
+
+        // Title label (centered)
+        let titleLabel = NSTextField(labelWithString: L("management.title"))
+        titleLabel.alignment = .center
+        titleLabel.font = .systemFont(ofSize: Self.titleFontSize, weight: .medium)
+        titleLabel.sizeToFit()
+        let labelWidth = titleBarFrame.width - Self.closeButtonSize * 2 - 8
+        titleLabel.frame = NSRect(
+            x: (titleBarFrame.width - labelWidth) / 2,
+            y: (titleBarHeight - titleLabel.frame.height) / 2,
+            width: labelWidth,
+            height: titleLabel.frame.height
+        )
+        bar.addSubview(titleLabel)
+    }
+
+    @objc private func closeTapped() {
+        dismiss()
+    }
+
+    // MARK: - Event Monitors
+
+    private func installEventMonitors() {
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+
+            // ESC key → dismiss
+            if event.keyCode == AppConstants.escKeyCode {
+                self.dismiss()
+                return nil
+            }
+
+            // Management panel hotkey re-press → dismiss
+            let binding = HotkeyManager.shared.binding(for: .managementPanel)
+            if HotkeyManager.shared.matches(event, binding: binding) {
+                self.dismiss()
+                return nil
+            }
+
+            return event
+        }
+    }
+
+    private func clearEventMonitors() {
+        if let monitor = keyMonitor {
+            NSEvent.removeMonitor(monitor)
+            keyMonitor = nil
+        }
+    }
+
+    deinit {
+        // deinit 時は参照が消滅するため nil 書き戻し不要
+        if let monitor = keyMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+}


### PR DESCRIPTION
## 概要

- `ManagementPanelController`: NSPanel + NSVisualEffectView で640×500のパネル骨格を作成
- タイトルバー（✕ボタン + タイトルラベル）、ESC / ホットキー再押しで閉じる
- `AppDelegate+ManagementPanel`: `setupManagementPanel` + `handleHotkeyAction` を実装
- `setupHotkeyMonitors()` を `HotkeyManager.matchingAction(for:)` ベースに書き換え
- 旧 `isOptionHotkey()` メソッドを削除

## テスト計画

- [x] `./build.sh` — SwiftLint含め正常ビルド
- [x] `xcodebuild test` — 全テストパス
- [x] `/simplify` レビュー 2回実施、指摘修正済み
- [x] 手動確認: Option+P でパネル表示/非表示
- [x] 手動確認: Option+H / Option+G が従来通り動作
- [x] 手動確認: ESC / ✕ / Option+P再押しでパネルが閉じる

Closes #28