### PR TITLE
feat: 管理パネル Phase 3 — サイドバー + タブ切替

### DIFF
--- a/Sobani.xcodeproj/project.pbxproj
+++ b/Sobani.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		F0HK000002000000000001 /* HotkeyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0HK000001000000000001 /* HotkeyManager.swift */; };
 		F0HK000004000000000001 /* HotkeyManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0HK000003000000000001 /* HotkeyManagerTests.swift */; };
 		F0MP000002000000000001 /* ManagementPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0MP000001000000000001 /* ManagementPanelController.swift */; };
+		F0MP000004000000000001 /* ManagementPanelController+Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0MP000003000000000001 /* ManagementPanelController+Setup.swift */; };
 		F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */; };
 /* End PBXBuildFile section */
 
@@ -214,6 +215,7 @@
 		F0HK000001000000000001 /* HotkeyManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManager.swift; sourceTree = "<group>"; };
 		F0HK000003000000000001 /* HotkeyManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyManagerTests.swift; sourceTree = "<group>"; };
 		F0MP000001000000000001 /* ManagementPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelController.swift; sourceTree = "<group>"; };
+		F0MP000003000000000001 /* ManagementPanelController+Setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagementPanelController+Setup.swift"; sourceTree = "<group>"; };
 		F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ManagementPanel.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -293,6 +295,7 @@
 				F0AF000001000000000001 /* AlertFactory.swift */,
 				F0HK000001000000000001 /* HotkeyManager.swift */,
 				F0MP000001000000000001 /* ManagementPanelController.swift */,
+				F0MP000003000000000001 /* ManagementPanelController+Setup.swift */,
 				F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */,
 				F0JP000001000000000001 /* JSONPersistence.swift */,
 				F0NP000001000000000001 /* NSPanel+FloatingConfig.swift */,
@@ -525,6 +528,7 @@
 				F0AF000002000000000001 /* AlertFactory.swift in Sources */,
 				F0HK000002000000000001 /* HotkeyManager.swift in Sources */,
 				F0MP000002000000000001 /* ManagementPanelController.swift in Sources */,
+				F0MP000004000000000001 /* ManagementPanelController+Setup.swift in Sources */,
 				F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */,
 				F0JP000002000000000001 /* JSONPersistence.swift in Sources */,
 				F0NP000002000000000001 /* NSPanel+FloatingConfig.swift in Sources */,

--- a/Sobani/ManagementPanelController+Setup.swift
+++ b/Sobani/ManagementPanelController+Setup.swift
@@ -1,0 +1,88 @@
+import Cocoa
+
+// MARK: - Setup Extensions
+
+extension ManagementPanelController {
+
+    func setupSidebar(in parent: NSView) {
+        let sidebarFrame = NSRect(
+            x: 0,
+            y: AppConstants.managementPanelStatusBarHeight,
+            width: AppConstants.managementPanelSidebarWidth,
+            height: AppConstants.managementPanelContentHeight
+        )
+        let sidebar = NSVisualEffectView(frame: sidebarFrame)
+        sidebar.material = .sidebar
+        sidebar.state = .active
+        sidebar.blendingMode = .behindWindow
+        parent.addSubview(sidebar)
+        sidebarView = sidebar
+
+        // Selection highlight view (behind buttons)
+        let highlightSize = Self.sidebarButtonSize
+        let highlightInset = Self.sidebarButtonInset
+        let highlight = NSView(frame: NSRect(x: highlightInset, y: 400, width: highlightSize, height: highlightSize))
+        highlight.wantsLayer = true
+        highlight.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(Self.sidebarHighlightAlpha).cgColor
+        highlight.layer?.cornerRadius = Self.sidebarHighlightCornerRadius
+        sidebar.addSubview(highlight, positioned: .below, relativeTo: nil)
+        sidebarHighlight = highlight
+
+        sidebarButtons = makeSidebarButtons(in: sidebar)
+    }
+
+    func setupContentContainer(in parent: NSView) {
+        let containerFrame = NSRect(
+            x: AppConstants.managementPanelSidebarWidth,
+            y: AppConstants.managementPanelStatusBarHeight,
+            width: AppConstants.managementPanelContentWidth,
+            height: AppConstants.managementPanelContentHeight
+        )
+        let container = NSView(frame: containerFrame)
+        parent.addSubview(container)
+        contentContainer = container
+    }
+
+    private func makeSidebarButtons(in parent: NSView) -> [NSButton] {
+        struct TabButtonSpec {
+            let symbolName: String
+            let tab: Tab
+            let yPosition: CGFloat
+        }
+        let specs = [
+            TabButtonSpec(symbolName: "square.on.square", tab: .windowManagement, yPosition: 400),
+            TabButtonSpec(symbolName: "rectangle.3.group", tab: .layout, yPosition: 356),
+            TabButtonSpec(symbolName: "gearshape", tab: .settings, yPosition: 4)
+        ]
+        var buttons: [NSButton] = []
+        for spec in specs {
+            let button = NSButton(frame: NSRect(x: Self.sidebarButtonInset, y: spec.yPosition, width: Self.sidebarButtonSize, height: Self.sidebarButtonSize))
+            button.bezelStyle = .regularSquare
+            button.isBordered = false
+            button.imagePosition = .imageOnly
+            button.image = SFSymbolUtils.icon(spec.symbolName, pointSize: 16, weight: .regular)
+            button.tag = spec.tab.rawValue
+            button.target = self
+            button.action = #selector(sidebarTabClicked(_:))
+            parent.addSubview(button)
+            buttons.append(button)
+        }
+        return buttons
+    }
+
+    func setupStatusBar(in parent: NSView) {
+        let statusFrame = NSRect(
+            x: AppConstants.managementPanelSidebarWidth,
+            y: 0,
+            width: AppConstants.managementPanelContentWidth,
+            height: AppConstants.managementPanelStatusBarHeight
+        )
+        let label = NSTextField(labelWithString: "")
+        label.frame = statusFrame
+        label.font = .systemFont(ofSize: 10)
+        label.textColor = .secondaryLabelColor
+        label.alignment = .center
+        parent.addSubview(label)
+        statusBar = label
+    }
+}

--- a/Sobani/ManagementPanelController.swift
+++ b/Sobani/ManagementPanelController.swift
@@ -20,13 +20,26 @@ final class ManagementPanelController: NSObject {
 
     private static let closeButtonSize: CGFloat = 20
     private static let titleFontSize: CGFloat = 13
+    // サイドバーボタン・ハイライトのサイズ・外観定数
+    static let sidebarButtonSize: CGFloat = 36
+    static let sidebarButtonInset: CGFloat = 4
+    static let sidebarHighlightCornerRadius: CGFloat = 8
+    static let sidebarHighlightAlpha: CGFloat = 0.15
+    static let sidebarTabAnimationDuration: TimeInterval = 0.15
 
     private let logger = Logger(category: "ManagementPanelController")
     private var panel: NSPanel?
     private var backgroundView: NSVisualEffectView?
-    private var contentContainer: NSView?
+    // 以下のプロパティは +Setup.swift extension から書き込まれるため internal
+    var contentContainer: NSView?
     private var titleBar: NSView?
+    var sidebarView: NSVisualEffectView?
+    var sidebarButtons: [NSButton] = []
+    var sidebarHighlight: NSView?
+    var statusBar: NSTextField?
+    private var activeTab: Tab = .windowManagement
     nonisolated(unsafe) private var keyMonitor: Any?
+    nonisolated(unsafe) private var appearanceObservation: NSKeyValueObservation?
     weak var delegate: ManagementPanelDelegate?
 
     var isVisible: Bool { panel?.isVisible ?? false }
@@ -109,10 +122,15 @@ final class ManagementPanelController: NSObject {
         effectView.layer?.masksToBounds = true
 
         setupTitleBar(in: effectView)
+        setupSidebar(in: effectView)
+        setupContentContainer(in: effectView)
+        setupStatusBar(in: effectView)
 
         newPanel.contentView = effectView
         backgroundView = effectView
         panel = newPanel
+
+        installAppearanceObserver()
     }
 
     private func setupTitleBar(in parent: NSView) {
@@ -160,6 +178,49 @@ final class ManagementPanelController: NSObject {
         dismiss()
     }
 
+    // MARK: - Tab Switching
+
+    @objc func sidebarTabClicked(_ sender: NSButton) {
+        guard let tab = Tab(rawValue: sender.tag) else { return }
+        switchTab(tab)
+    }
+
+    func switchTab(_ tab: Tab) {
+        activeTab = tab
+        contentContainer?.subviews.forEach { $0.removeFromSuperview() }
+        updateSidebarHighlight(tab)
+        updateStatusBar()
+    }
+
+    private func updateSidebarHighlight(_ tab: Tab) {
+        // Tab.rawValue (0,1,2) と1:1対応: windowManagement=400, layout=356, settings=4
+        let yPositions: [CGFloat] = [400, 356, 4]
+        guard tab.rawValue < yPositions.count else { return }
+        NSAnimationContext.runAnimationGroup { ctx in
+            ctx.duration = Self.sidebarTabAnimationDuration
+            sidebarHighlight?.animator().frame.origin.y = yPositions[tab.rawValue]
+        }
+    }
+
+    func updateStatusBar() {
+        statusBar?.stringValue = ""
+    }
+
+    // MARK: - Appearance
+
+    private func installAppearanceObserver() {
+        appearanceObservation = NSApp.observe(\.effectiveAppearance) { [weak self] _, _ in
+            DispatchQueue.main.async { [weak self] in
+                self?.updateAppearanceDependentColors()
+            }
+        }
+    }
+
+    private func updateAppearanceDependentColors() {
+        sidebarHighlight?.layer?.backgroundColor =
+            NSColor.controlAccentColor.withAlphaComponent(Self.sidebarHighlightAlpha).cgColor
+    }
+
     // MARK: - Event Monitors
 
     private func installEventMonitors() {
@@ -195,5 +256,6 @@ final class ManagementPanelController: NSObject {
         if let monitor = keyMonitor {
             NSEvent.removeMonitor(monitor)
         }
+        appearanceObservation?.invalidate()
     }
 }


### PR DESCRIPTION
## 概要

- サイドバーナビゲーション（3タブ: ウィンドウ管理・レイアウト・設定）
- ウィンドウ管理/レイアウトは左上に並べ、設定は左下に固定配置
- アニメーション付きハイライト移動でタブ切替
- ステータスバー（パネル下部、Phase 4で表示数を連動）
- ダーク/ライトモード対応（外観変更時にハイライト色再適用）
- SwiftLint対応: setup系を +Setup.swift に分離

## テスト計画

- [x] `./build.sh` — SwiftLint含め正常ビルド
- [x] `xcodebuild test` — 全テストパス
- [x] `/simplify` レビュー 2回実施、マジックナンバー定数化等の修正済み

Closes #29