### PR TITLE
feat: 管理パネル Phase 4 — ウィンドウリスト + 詳細ペイン

### DIFF
--- a/Sobani.xcodeproj/project.pbxproj
+++ b/Sobani.xcodeproj/project.pbxproj
@@ -103,6 +103,8 @@
 		F0MP000002000000000001 /* ManagementPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0MP000001000000000001 /* ManagementPanelController.swift */; };
 		F0MP000004000000000001 /* ManagementPanelController+Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0MP000003000000000001 /* ManagementPanelController+Setup.swift */; };
 		F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */; };
+		F0WL000002000000000001 /* ManagementPanelWindowListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0WL000001000000000001 /* ManagementPanelWindowListView.swift */; };
+		F0DV000002000000000001 /* ManagementPanelDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DV000001000000000001 /* ManagementPanelDetailView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -217,6 +219,8 @@
 		F0MP000001000000000001 /* ManagementPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelController.swift; sourceTree = "<group>"; };
 		F0MP000003000000000001 /* ManagementPanelController+Setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagementPanelController+Setup.swift"; sourceTree = "<group>"; };
 		F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ManagementPanel.swift"; sourceTree = "<group>"; };
+		F0WL000001000000000001 /* ManagementPanelWindowListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelWindowListView.swift; sourceTree = "<group>"; };
+		F0DV000001000000000001 /* ManagementPanelDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelDetailView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -296,6 +300,8 @@
 				F0HK000001000000000001 /* HotkeyManager.swift */,
 				F0MP000001000000000001 /* ManagementPanelController.swift */,
 				F0MP000003000000000001 /* ManagementPanelController+Setup.swift */,
+				F0WL000001000000000001 /* ManagementPanelWindowListView.swift */,
+				F0DV000001000000000001 /* ManagementPanelDetailView.swift */,
 				F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */,
 				F0JP000001000000000001 /* JSONPersistence.swift */,
 				F0NP000001000000000001 /* NSPanel+FloatingConfig.swift */,
@@ -529,6 +535,8 @@
 				F0HK000002000000000001 /* HotkeyManager.swift in Sources */,
 				F0MP000002000000000001 /* ManagementPanelController.swift in Sources */,
 				F0MP000004000000000001 /* ManagementPanelController+Setup.swift in Sources */,
+				F0WL000002000000000001 /* ManagementPanelWindowListView.swift in Sources */,
+				F0DV000002000000000001 /* ManagementPanelDetailView.swift in Sources */,
 				F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */,
 				F0JP000002000000000001 /* JSONPersistence.swift in Sources */,
 				F0NP000002000000000001 /* NSPanel+FloatingConfig.swift in Sources */,

--- a/Sobani/AppDelegate+ManagementPanel.swift
+++ b/Sobani/AppDelegate+ManagementPanel.swift
@@ -23,4 +23,23 @@ extension AppDelegate {
 
 // MARK: - ManagementPanelDelegate
 
-extension AppDelegate: ManagementPanelDelegate {}
+extension AppDelegate: ManagementPanelDelegate {
+    var managedWindows: [CharacterWindow] {
+        zOrderedWindows
+    }
+
+    func managementPanel(_ panel: ManagementPanelController, didToggleVisibility charWindow: CharacterWindow) {
+        charWindow.setHidden(!charWindow.isHidden)
+        if !charWindow.isHidden {
+            applyZOrderToWindows()
+        }
+    }
+
+    func managementPanel(_ panel: ManagementPanelController, didToggleGhostMode charWindow: CharacterWindow) {
+        charWindow.setGhostMode(!charWindow.isGhostMode)
+    }
+
+    func managementPanel(_ panel: ManagementPanelController, didChangeOpacity opacity: CGFloat, for charWindow: CharacterWindow) {
+        charWindow.applyOpacity(opacity)
+    }
+}

--- a/Sobani/Localizable.xcstrings
+++ b/Sobani/Localizable.xcstrings
@@ -3696,6 +3696,70 @@
           }
         }
       }
+    },
+    "management.select_window": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウを選択してください"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a window"
+          }
+        }
+      }
+    },
+    "management.opacity": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "不透明度"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opacity"
+          }
+        }
+      }
+    },
+    "management.ghost_mode": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ゴースト"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghost"
+          }
+        }
+      }
+    },
+    "management.visibility": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visible"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sobani/ManagementPanelController+Setup.swift
+++ b/Sobani/ManagementPanelController+Setup.swift
@@ -4,6 +4,72 @@ import Cocoa
 
 extension ManagementPanelController {
 
+    // MARK: - Content Views
+
+    func setupContentViews() {
+        guard let container = contentContainer else { return }
+        let contentHeight = AppConstants.managementPanelContentHeight
+        let listWidth = AppConstants.managementPanelListWidth
+        let detailWidth = AppConstants.managementPanelDetailWidth
+
+        let listView = ManagementPanelWindowListView(frame: NSRect(
+            x: 0, y: 0, width: listWidth, height: contentHeight
+        ))
+        listView.onWindowSelected = { [weak self] charWindow in
+            self?.detailView?.update(with: charWindow)
+        }
+        listView.onVisibilityToggled = { [weak self] charWindow in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didToggleVisibility: charWindow)
+            self.reloadWindowList()
+        }
+        listView.onGhostToggled = { [weak self] charWindow in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didToggleGhostMode: charWindow)
+            self.reloadWindowList()
+        }
+        container.addSubview(listView)
+        windowListView = listView
+
+        // Vertical divider
+        let divider = NSBox(frame: NSRect(x: listWidth, y: 0, width: 1, height: contentHeight))
+        divider.boxType = .separator
+        container.addSubview(divider)
+
+        let detail = ManagementPanelDetailView(frame: NSRect(
+            x: listWidth + 1, y: 0, width: detailWidth - 1, height: contentHeight
+        ))
+        detail.onOpacityChanged = { [weak self] charWindow, opacity in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didChangeOpacity: opacity, for: charWindow)
+        }
+        detail.onGhostToggled = { [weak self] charWindow in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didToggleGhostMode: charWindow)
+            self.reloadWindowList()
+            self.detailView?.update(with: charWindow)
+        }
+        detail.onVisibilityToggled = { [weak self] charWindow in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didToggleVisibility: charWindow)
+            self.reloadWindowList()
+            self.detailView?.update(with: charWindow)
+        }
+        container.addSubview(detail)
+        detailView = detail
+    }
+
+    func reloadWindowList() {
+        guard let delegate else { return }
+        let windows = delegate.managedWindows
+        windowListView?.reload(with: windows)
+        updateStatusBar()
+        // 現在選択中のウィンドウの詳細も更新
+        if let selected = windowListView?.selectedWindow {
+            detailView?.update(with: selected)
+        }
+    }
+
     func setupSidebar(in parent: NSView) {
         let sidebarFrame = NSRect(
             x: 0,
@@ -21,7 +87,8 @@ extension ManagementPanelController {
         // Selection highlight view (behind buttons)
         let highlightSize = Self.sidebarButtonSize
         let highlightInset = Self.sidebarButtonInset
-        let highlight = NSView(frame: NSRect(x: highlightInset, y: 400, width: highlightSize, height: highlightSize))
+        let initialHighlightY = Self.sidebarTabYPositions[Tab.windowManagement.rawValue]
+        let highlight = NSView(frame: NSRect(x: highlightInset, y: initialHighlightY, width: highlightSize, height: highlightSize))
         highlight.wantsLayer = true
         highlight.layer?.backgroundColor = NSColor.controlAccentColor.withAlphaComponent(Self.sidebarHighlightAlpha).cgColor
         highlight.layer?.cornerRadius = Self.sidebarHighlightCornerRadius
@@ -50,9 +117,12 @@ extension ManagementPanelController {
             let yPosition: CGFloat
         }
         let specs = [
-            TabButtonSpec(symbolName: "square.on.square", tab: .windowManagement, yPosition: 400),
-            TabButtonSpec(symbolName: "rectangle.3.group", tab: .layout, yPosition: 356),
-            TabButtonSpec(symbolName: "gearshape", tab: .settings, yPosition: 4)
+            TabButtonSpec(symbolName: "square.on.square", tab: .windowManagement,
+                          yPosition: Self.sidebarTabYPositions[Tab.windowManagement.rawValue]),
+            TabButtonSpec(symbolName: "rectangle.3.group", tab: .layout,
+                          yPosition: Self.sidebarTabYPositions[Tab.layout.rawValue]),
+            TabButtonSpec(symbolName: "gearshape", tab: .settings,
+                          yPosition: Self.sidebarTabYPositions[Tab.settings.rawValue])
         ]
         var buttons: [NSButton] = []
         for spec in specs {
@@ -60,7 +130,7 @@ extension ManagementPanelController {
             button.bezelStyle = .regularSquare
             button.isBordered = false
             button.imagePosition = .imageOnly
-            button.image = SFSymbolUtils.icon(spec.symbolName, pointSize: 16, weight: .regular)
+            button.image = SFSymbolUtils.icon(spec.symbolName, pointSize: Self.sidebarButtonIconPointSize, weight: .regular)
             button.tag = spec.tab.rawValue
             button.target = self
             button.action = #selector(sidebarTabClicked(_:))
@@ -79,7 +149,7 @@ extension ManagementPanelController {
         )
         let label = NSTextField(labelWithString: "")
         label.frame = statusFrame
-        label.font = .systemFont(ofSize: 10)
+        label.font = .systemFont(ofSize: Self.statusBarFontSize)
         label.textColor = .secondaryLabelColor
         label.alignment = .center
         parent.addSubview(label)

--- a/Sobani/ManagementPanelController.swift
+++ b/Sobani/ManagementPanelController.swift
@@ -5,7 +5,10 @@ import os.log
 
 @MainActor
 protocol ManagementPanelDelegate: AnyObject {
-    // Phase 4 でウィンドウ操作の通知メソッドを追加予定
+    var managedWindows: [CharacterWindow] { get }
+    func managementPanel(_ panel: ManagementPanelController, didToggleVisibility charWindow: CharacterWindow)
+    func managementPanel(_ panel: ManagementPanelController, didToggleGhostMode charWindow: CharacterWindow)
+    func managementPanel(_ panel: ManagementPanelController, didChangeOpacity opacity: CGFloat, for charWindow: CharacterWindow)
 }
 
 // MARK: - ManagementPanelController
@@ -20,12 +23,19 @@ final class ManagementPanelController: NSObject {
 
     private static let closeButtonSize: CGFloat = 20
     private static let titleFontSize: CGFloat = 13
+    private static let closeButtonX: CGFloat = 4
+    private static let titleLabelPadding: CGFloat = 8
+    private static let closeIconPointSize: CGFloat = 14
     // サイドバーボタン・ハイライトのサイズ・外観定数
     static let sidebarButtonSize: CGFloat = 36
     static let sidebarButtonInset: CGFloat = 4
     static let sidebarHighlightCornerRadius: CGFloat = 8
     static let sidebarHighlightAlpha: CGFloat = 0.15
     static let sidebarTabAnimationDuration: TimeInterval = 0.15
+    // サイドバータブボタンの y 座標（Tab.rawValue の順と一致）
+    static let sidebarTabYPositions: [CGFloat] = [400, 356, 4]
+    static let sidebarButtonIconPointSize: CGFloat = 16
+    static let statusBarFontSize: CGFloat = 10
 
     private let logger = Logger(category: "ManagementPanelController")
     private var panel: NSPanel?
@@ -41,6 +51,8 @@ final class ManagementPanelController: NSObject {
     nonisolated(unsafe) private var keyMonitor: Any?
     nonisolated(unsafe) private var appearanceObservation: NSKeyValueObservation?
     weak var delegate: ManagementPanelDelegate?
+    var windowListView: ManagementPanelWindowListView?
+    var detailView: ManagementPanelDetailView?
 
     var isVisible: Bool { panel?.isVisible ?? false }
 
@@ -82,6 +94,7 @@ final class ManagementPanelController: NSObject {
         panel.setFrameOrigin(origin)
         panel.makeKeyAndOrderFront(nil)
 
+        reloadWindowList()
         clearEventMonitors()
         installEventMonitors()
     }
@@ -131,6 +144,7 @@ final class ManagementPanelController: NSObject {
         panel = newPanel
 
         installAppearanceObserver()
+        switchTab(.windowManagement)
     }
 
     private func setupTitleBar(in parent: NSView) {
@@ -149,12 +163,17 @@ final class ManagementPanelController: NSObject {
         titleBar = bar
 
         // Close button (✕)
-        let closeButtonFrame = NSRect(x: 4, y: (titleBarHeight - Self.closeButtonSize) / 2, width: Self.closeButtonSize, height: Self.closeButtonSize)
+        let closeButtonFrame = NSRect(
+            x: Self.closeButtonX,
+            y: (titleBarHeight - Self.closeButtonSize) / 2,
+            width: Self.closeButtonSize,
+            height: Self.closeButtonSize
+        )
         let closeButton = NSButton(frame: closeButtonFrame)
         closeButton.bezelStyle = .regularSquare
         closeButton.isBordered = false
         closeButton.imagePosition = .imageOnly
-        closeButton.image = SFSymbolUtils.icon("xmark.circle.fill", pointSize: 14, weight: .regular)
+        closeButton.image = SFSymbolUtils.icon("xmark.circle.fill", pointSize: Self.closeIconPointSize, weight: .regular)
         closeButton.target = self
         closeButton.action = #selector(closeTapped)
         bar.addSubview(closeButton)
@@ -164,7 +183,7 @@ final class ManagementPanelController: NSObject {
         titleLabel.alignment = .center
         titleLabel.font = .systemFont(ofSize: Self.titleFontSize, weight: .medium)
         titleLabel.sizeToFit()
-        let labelWidth = titleBarFrame.width - Self.closeButtonSize * 2 - 8
+        let labelWidth = titleBarFrame.width - Self.closeButtonSize * 2 - Self.titleLabelPadding
         titleLabel.frame = NSRect(
             x: (titleBarFrame.width - labelWidth) / 2,
             y: (titleBarHeight - titleLabel.frame.height) / 2,
@@ -189,21 +208,33 @@ final class ManagementPanelController: NSObject {
         activeTab = tab
         contentContainer?.subviews.forEach { $0.removeFromSuperview() }
         updateSidebarHighlight(tab)
+        if tab == .windowManagement {
+            setupContentViews()
+        }
         updateStatusBar()
     }
 
     private func updateSidebarHighlight(_ tab: Tab) {
-        // Tab.rawValue (0,1,2) と1:1対応: windowManagement=400, layout=356, settings=4
-        let yPositions: [CGFloat] = [400, 356, 4]
-        guard tab.rawValue < yPositions.count else { return }
+        // Tab.rawValue (0,1,2) と1:1対応
+        guard tab.rawValue < Self.sidebarTabYPositions.count else { return }
         NSAnimationContext.runAnimationGroup { ctx in
             ctx.duration = Self.sidebarTabAnimationDuration
-            sidebarHighlight?.animator().frame.origin.y = yPositions[tab.rawValue]
+            sidebarHighlight?.animator().frame.origin.y = Self.sidebarTabYPositions[tab.rawValue]
         }
     }
 
     func updateStatusBar() {
-        statusBar?.stringValue = ""
+        guard let delegate else {
+            statusBar?.stringValue = ""
+            return
+        }
+        if activeTab == .windowManagement {
+            let all = delegate.managedWindows
+            let visible = all.filter { !$0.isHidden }.count
+            statusBar?.stringValue = "\(visible)/\(all.count) 表示中"
+        } else {
+            statusBar?.stringValue = ""
+        }
     }
 
     // MARK: - Appearance

--- a/Sobani/ManagementPanelDetailView.swift
+++ b/Sobani/ManagementPanelDetailView.swift
@@ -1,0 +1,287 @@
+import Cocoa
+import os.log
+
+// MARK: - ManagementPanelDetailView
+
+@MainActor
+final class ManagementPanelDetailView: NSView {
+    // Layout constants
+    private static let contentHeight: CGFloat = AppConstants.managementPanelContentHeight
+    private static let previewMaxWidth: CGFloat = AppConstants.managementPanelPreviewMaxWidth
+    private static let previewMaxHeight: CGFloat = AppConstants.managementPanelPreviewMaxHeight
+    private static let marginX: CGFloat = 18
+    private static let previewTop: CGFloat = 16
+    private static let separatorTop: CGFloat = 204
+    private static let nameLabelTop: CGFloat = 216
+    private static let idLabelTop: CGFloat = 240
+    private static let screenLabelTop: CGFloat = 258
+    private static let opacityRowTop: CGFloat = 290
+    private static let ghostRowTop: CGFloat = 320
+    private static let visibilityRowTop: CGFloat = 350
+    private static let opacitySliderX: CGFloat = 82
+    private static let opacitySliderWidth: CGFloat = 200
+    private static let opacityPercentX: CGFloat = 290
+    private static let opacityPercentWidth: CGFloat = 45
+    private static let switchX: CGFloat = 102
+    // フォントサイズ
+    private static let nameFontSize: CGFloat = 14
+    private static let rowLabelFontSize: CGFloat = 12
+    private static let smallLabelFontSize: CGFloat = 11
+    // 行・ラベルのサイズ
+    private static let rowHeight: CGFloat = 20
+    private static let nameLabelHeight: CGFloat = 17
+    private static let idLabelHeight: CGFloat = 14
+    private static let screenLabelHeight: CGFloat = 13
+    private static let rowLabelWidth: CGFloat = 80
+    private static let opacityLabelWidth: CGFloat = 60
+
+    private let logger = Logger(category: "ManagementPanelDetailView")
+    private var imagePreview: NSImageView?
+    private var nameLabel: NSTextField?
+    private var sizeLabel: NSTextField?
+    private var screenLabel: NSTextField?
+    private var opacitySlider: NSSlider?
+    private var opacityLabel: NSTextField?
+    private var ghostSwitch: NSSwitch?
+    private var visibilitySwitch: NSSwitch?
+    private var emptyLabel: NSTextField?
+    private weak var currentWindow: CharacterWindow?
+
+    var onOpacityChanged: ((CharacterWindow, CGFloat) -> Void)?
+    var onGhostToggled: ((CharacterWindow) -> Void)?
+    var onVisibilityToggled: ((CharacterWindow) -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        buildUI()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        buildUI()
+    }
+
+    // MARK: - Setup
+
+    private func buildUI() {
+        buildEmptyState()
+        buildPreview()
+        buildSeparator()
+        buildLabels()
+        buildOpacityRow()
+        buildGhostRow()
+        buildVisibilityRow()
+
+        showEmpty()
+    }
+
+    private func buildEmptyState() {
+        let label = NSTextField(labelWithString: L("management.select_window"))
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = .secondaryLabelColor
+        label.alignment = .center
+        label.sizeToFit()
+        label.frame = NSRect(
+            x: (bounds.width - label.frame.width) / 2,
+            y: (bounds.height - label.frame.height) / 2,
+            width: label.frame.width,
+            height: label.frame.height
+        )
+        label.autoresizingMask = [.minXMargin, .maxXMargin, .minYMargin, .maxYMargin]
+        addSubview(label)
+        emptyLabel = label
+    }
+
+    private func buildPreview() {
+        let previewY = Self.contentHeight - Self.previewTop - Self.previewMaxHeight
+        let preview = NSImageView(frame: NSRect(
+            x: Self.marginX,
+            y: previewY,
+            width: Self.previewMaxWidth,
+            height: Self.previewMaxHeight
+        ))
+        preview.imageScaling = .scaleProportionallyUpOrDown
+        preview.imageAlignment = .alignCenter
+        addSubview(preview)
+        imagePreview = preview
+    }
+
+    private func buildSeparator() {
+        let sepY = Self.contentHeight - Self.separatorTop - 1
+        let sep = NSBox(frame: NSRect(x: Self.marginX, y: sepY, width: Self.previewMaxWidth, height: 1))
+        sep.boxType = .separator
+        addSubview(sep)
+    }
+
+    private func buildLabels() {
+        // Display name
+        let nameLabelY = Self.contentHeight - Self.nameLabelTop - Self.nameLabelHeight
+        let name = NSTextField(labelWithString: "")
+        name.font = .systemFont(ofSize: Self.nameFontSize, weight: .semibold)
+        name.frame = NSRect(x: Self.marginX, y: nameLabelY, width: Self.previewMaxWidth, height: Self.nameLabelHeight)
+        name.lineBreakMode = .byTruncatingTail
+        addSubview(name)
+        nameLabel = name
+
+        // Size / ID label
+        let sizeLabelY = Self.contentHeight - Self.idLabelTop - Self.idLabelHeight
+        let size = NSTextField(labelWithString: "")
+        size.font = .monospacedDigitSystemFont(ofSize: Self.smallLabelFontSize, weight: .regular)
+        size.textColor = .secondaryLabelColor
+        size.frame = NSRect(x: Self.marginX, y: sizeLabelY, width: Self.previewMaxWidth, height: Self.idLabelHeight)
+        addSubview(size)
+        sizeLabel = size
+
+        // Screen name label
+        let screenLabelY = Self.contentHeight - Self.screenLabelTop - Self.screenLabelHeight
+        let screen = NSTextField(labelWithString: "")
+        screen.font = .systemFont(ofSize: Self.smallLabelFontSize)
+        screen.textColor = .secondaryLabelColor
+        screen.frame = NSRect(x: Self.marginX, y: screenLabelY, width: Self.previewMaxWidth, height: Self.screenLabelHeight)
+        addSubview(screen)
+        screenLabel = screen
+    }
+
+    private func buildOpacityRow() {
+        let rowY = Self.contentHeight - Self.opacityRowTop - Self.rowHeight
+
+        // "不透明度" label
+        let label = NSTextField(labelWithString: L("management.opacity"))
+        label.font = .systemFont(ofSize: Self.rowLabelFontSize)
+        label.frame = NSRect(x: Self.marginX, y: rowY, width: Self.opacityLabelWidth, height: Self.rowHeight)
+        addSubview(label)
+
+        // Slider
+        let slider = NSSlider(value: 1.0, minValue: Double(AppConstants.opacityMin),
+                              maxValue: Double(AppConstants.opacityMax), target: self,
+                              action: #selector(opacitySliderChanged(_:)))
+        slider.frame = NSRect(x: Self.opacitySliderX, y: rowY,
+                              width: Self.opacitySliderWidth, height: Self.rowHeight)
+        slider.isContinuous = true
+        addSubview(slider)
+        opacitySlider = slider
+
+        // Percent label
+        let pctLabel = NSTextField(labelWithString: "100%")
+        pctLabel.font = .monospacedDigitSystemFont(ofSize: Self.smallLabelFontSize, weight: .regular)
+        pctLabel.alignment = .right
+        pctLabel.frame = NSRect(x: Self.opacityPercentX, y: rowY,
+                                width: Self.opacityPercentWidth, height: Self.rowHeight)
+        addSubview(pctLabel)
+        opacityLabel = pctLabel
+    }
+
+    private func buildGhostRow() {
+        let rowY = Self.contentHeight - Self.ghostRowTop - Self.rowHeight
+
+        let label = NSTextField(labelWithString: L("management.ghost_mode"))
+        label.font = .systemFont(ofSize: Self.rowLabelFontSize)
+        label.frame = NSRect(x: Self.marginX, y: rowY, width: Self.rowLabelWidth, height: Self.rowHeight)
+        addSubview(label)
+
+        let ghostSw = NSSwitch()
+        ghostSw.controlSize = .small
+        ghostSw.sizeToFit()
+        ghostSw.frame.origin = NSPoint(x: Self.switchX, y: rowY)
+        ghostSw.target = self
+        ghostSw.action = #selector(ghostSwitchChanged(_:))
+        addSubview(ghostSw)
+        ghostSwitch = ghostSw
+    }
+
+    private func buildVisibilityRow() {
+        let rowY = Self.contentHeight - Self.visibilityRowTop - Self.rowHeight
+
+        let label = NSTextField(labelWithString: L("management.visibility"))
+        label.font = .systemFont(ofSize: Self.rowLabelFontSize)
+        label.frame = NSRect(x: Self.marginX, y: rowY, width: Self.rowLabelWidth, height: Self.rowHeight)
+        addSubview(label)
+
+        let visibilitySw = NSSwitch()
+        visibilitySw.controlSize = .small
+        visibilitySw.sizeToFit()
+        visibilitySw.frame.origin = NSPoint(x: Self.switchX, y: rowY)
+        visibilitySw.target = self
+        visibilitySw.action = #selector(visibilitySwitchChanged(_:))
+        addSubview(visibilitySw)
+        visibilitySwitch = visibilitySw
+    }
+
+    // MARK: - Public API
+
+    func update(with charWindow: CharacterWindow?) {
+        guard let charWindow else {
+            showEmpty()
+            return
+        }
+        currentWindow = charWindow
+        setContentVisible(true)
+
+        // Image preview
+        let image = ImageManager.shared.loadRegisteredImageCached(named: charWindow.displayName)
+            ?? charWindow.imageView.image
+        imagePreview?.image = image
+
+        // Name
+        nameLabel?.stringValue = charWindow.localizedDisplayName
+
+        // Window size
+        let winFrame = charWindow.window.frame
+        let winW = Int(winFrame.width)
+        let winH = Int(winFrame.height)
+        sizeLabel?.stringValue = "#\(charWindow.windowId)  \(winW)×\(winH)"
+
+        // Screen
+        screenLabel?.stringValue = charWindow.window.screen?.localizedName ?? ""
+
+        // Opacity
+        let opacity = charWindow.imageView.opacityLevel
+        opacitySlider?.doubleValue = Double(opacity)
+        opacityLabel?.stringValue = FormatUtils.formatOpacity(opacity)
+
+        // Ghost switch
+        ghostSwitch?.state = charWindow.isGhostMode ? .on : .off
+
+        // Visibility switch
+        visibilitySwitch?.state = charWindow.isHidden ? .off : .on
+    }
+
+    func showEmpty() {
+        currentWindow = nil
+        setContentVisible(false)
+    }
+
+    // MARK: - Helpers
+
+    private func setContentVisible(_ visible: Bool) {
+        emptyLabel?.isHidden = visible
+        imagePreview?.isHidden = !visible
+        nameLabel?.isHidden = !visible
+        sizeLabel?.isHidden = !visible
+        screenLabel?.isHidden = !visible
+        opacitySlider?.isHidden = !visible
+        opacityLabel?.isHidden = !visible
+        ghostSwitch?.isHidden = !visible
+        visibilitySwitch?.isHidden = !visible
+        // separators and row labels always visible is fine when empty
+    }
+
+    // MARK: - Actions
+
+    @objc private func opacitySliderChanged(_ sender: NSSlider) {
+        let value = CGFloat(sender.doubleValue)
+        opacityLabel?.stringValue = FormatUtils.formatOpacity(value)
+        guard let charWindow = currentWindow else { return }
+        onOpacityChanged?(charWindow, value)
+    }
+
+    @objc private func ghostSwitchChanged(_ sender: NSSwitch) {
+        guard let charWindow = currentWindow else { return }
+        onGhostToggled?(charWindow)
+    }
+
+    @objc private func visibilitySwitchChanged(_ sender: NSSwitch) {
+        guard let charWindow = currentWindow else { return }
+        onVisibilityToggled?(charWindow)
+    }
+}

--- a/Sobani/ManagementPanelWindowListView.swift
+++ b/Sobani/ManagementPanelWindowListView.swift
@@ -1,0 +1,251 @@
+import Cocoa
+import os.log
+
+// MARK: - ManagementPanelWindowListView
+
+@MainActor
+final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTableViewDelegate {
+    private static let indexLabelSize: CGFloat = 16
+    private static let indexLabelX: CGFloat = 8
+    private static let nameLabelX: CGFloat = 28
+    private static let nameLabelY: CGFloat = 22
+    private static let nameLabelWidth: CGFloat = 100
+    private static let nameLabelHeight: CGFloat = 16
+    private static let idLabelY: CGFloat = 6
+    private static let idLabelHeight: CGFloat = 12
+    private static let eyeButtonX: CGFloat = 132
+    private static let ghostButtonX: CGFloat = 160
+    private static let actionButtonSize: CGFloat = 24
+
+    private let logger = Logger(category: "ManagementPanelWindowListView")
+    private var tableView: NSTableView?
+    private var scrollView: NSScrollView?
+    private(set) var windows: [CharacterWindow] = []
+    private(set) var selectedWindow: CharacterWindow?
+
+    var onWindowSelected: ((CharacterWindow?) -> Void)?
+    var onVisibilityToggled: ((CharacterWindow) -> Void)?
+    var onGhostToggled: ((CharacterWindow) -> Void)?
+    var onReorder: ((CharacterWindow, Int) -> Void)?
+    var onBulkAction: ((BulkAction) -> Void)?
+
+    enum BulkAction {
+        case showAll
+        case hideAll
+        case ghostAll
+        case unghostAll
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupTableView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupTableView()
+    }
+
+    // MARK: - Setup
+
+    private func setupTableView() {
+        let scroll = NSScrollView(frame: bounds)
+        scroll.autoresizingMask = [.width, .height]
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .noBorder
+        addSubview(scroll)
+        scrollView = scroll
+
+        let table = NSTableView(frame: scroll.bounds)
+        table.dataSource = self
+        table.delegate = self
+        table.rowHeight = AppConstants.managementPanelRowHeight
+        table.selectionHighlightStyle = .none
+        table.backgroundColor = .clear
+        table.headerView = nil
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("window"))
+        column.width = AppConstants.managementPanelListWidth
+        table.addTableColumn(column)
+
+        scroll.documentView = table
+        tableView = table
+    }
+
+    // MARK: - Public API
+
+    func reload(with windows: [CharacterWindow]) {
+        self.windows = windows
+        tableView?.reloadData()
+    }
+
+    func selectWindow(_ charWindow: CharacterWindow?) {
+        selectedWindow = charWindow
+        guard let table = tableView else { return }
+        if let charWindow, let index = windows.firstIndex(where: { $0 === charWindow }) {
+            table.selectRowIndexes(IndexSet(integer: index), byExtendingSelection: false)
+        } else {
+            table.deselectAll(nil)
+        }
+    }
+
+    // MARK: - NSTableViewDataSource
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        windows.count
+    }
+
+    // MARK: - NSTableViewDelegate
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        guard row < windows.count else { return nil }
+        let charWindow = windows[row]
+
+        let identifier = NSUserInterfaceItemIdentifier("WindowCell")
+        let cellView: NSView
+        if let reused = tableView.makeView(withIdentifier: identifier, owner: self) {
+            cellView = reused
+            cellView.subviews.forEach { $0.removeFromSuperview() }
+        } else {
+            cellView = NSView()
+            cellView.identifier = identifier
+        }
+
+        buildCellContent(in: cellView, charWindow: charWindow, index: row)
+        return cellView
+    }
+
+    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        let rowView = ManagementPanelRowView()
+        guard row < windows.count else { return rowView }
+        let charWindow = windows[row]
+        let isSelected = charWindow === selectedWindow
+        rowView.isHighlighted = isSelected
+        rowView.alphaValue = charWindow.isHidden ? 0.5 : 1.0
+        return rowView
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        guard let table = tableView else { return }
+        let row = table.selectedRow
+        if row >= 0, row < windows.count {
+            selectedWindow = windows[row]
+        } else {
+            selectedWindow = nil
+        }
+        onWindowSelected?(selectedWindow)
+        table.reloadData()
+    }
+
+    // MARK: - Cell Building
+
+    private func buildCellContent(in cellView: NSView, charWindow: CharacterWindow, index: Int) {
+        let rowHeight = AppConstants.managementPanelRowHeight
+
+        // Index label
+        let indexLabel = NSTextField(labelWithString: "\(index + 1)")
+        indexLabel.font = .monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        indexLabel.textColor = .secondaryLabelColor
+        indexLabel.frame = NSRect(
+            x: Self.indexLabelX,
+            y: (rowHeight - Self.indexLabelSize) / 2,
+            width: Self.indexLabelSize,
+            height: Self.indexLabelSize
+        )
+        cellView.addSubview(indexLabel)
+
+        // Display name label
+        let nameLabel = NSTextField(labelWithString: charWindow.localizedDisplayName)
+        nameLabel.font = .systemFont(ofSize: 12)
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.frame = NSRect(
+            x: Self.nameLabelX,
+            y: Self.nameLabelY,
+            width: Self.nameLabelWidth,
+            height: Self.nameLabelHeight
+        )
+        cellView.addSubview(nameLabel)
+
+        // Window ID label
+        let idLabel = NSTextField(labelWithString: "#\(charWindow.windowId)")
+        idLabel.font = .systemFont(ofSize: 10)
+        idLabel.textColor = .tertiaryLabelColor
+        idLabel.frame = NSRect(
+            x: Self.nameLabelX,
+            y: Self.idLabelY,
+            width: Self.nameLabelWidth,
+            height: Self.idLabelHeight
+        )
+        cellView.addSubview(idLabel)
+
+        // Eye button (visibility toggle)
+        let eyeSymbol = charWindow.isHidden ? AppConstants.hiddenWindowSymbol : AppConstants.visibleWindowSymbol
+        let eyeButton = NSButton(frame: NSRect(
+            x: Self.eyeButtonX,
+            y: (rowHeight - Self.actionButtonSize) / 2,
+            width: Self.actionButtonSize,
+            height: Self.actionButtonSize
+        ))
+        eyeButton.bezelStyle = .regularSquare
+        eyeButton.isBordered = false
+        eyeButton.imagePosition = .imageOnly
+        eyeButton.image = SFSymbolUtils.icon(eyeSymbol, pointSize: 14, weight: .regular)
+        eyeButton.tag = index
+        eyeButton.target = self
+        eyeButton.action = #selector(eyeButtonTapped(_:))
+        cellView.addSubview(eyeButton)
+
+        // Ghost button
+        let ghostButton = NSButton(frame: NSRect(
+            x: Self.ghostButtonX,
+            y: (rowHeight - Self.actionButtonSize) / 2,
+            width: Self.actionButtonSize,
+            height: Self.actionButtonSize
+        ))
+        ghostButton.bezelStyle = .regularSquare
+        ghostButton.isBordered = false
+        ghostButton.imagePosition = .imageOnly
+        ghostButton.image = SFSymbolUtils.icon(AppConstants.ghostModeSymbol, pointSize: 14, weight: .regular)
+        if charWindow.isGhostMode {
+            ghostButton.contentTintColor = .controlAccentColor
+        } else {
+            ghostButton.contentTintColor = nil
+        }
+        ghostButton.tag = index
+        ghostButton.target = self
+        ghostButton.action = #selector(ghostButtonTapped(_:))
+        cellView.addSubview(ghostButton)
+    }
+
+    // MARK: - Actions
+
+    @objc private func eyeButtonTapped(_ sender: NSButton) {
+        let index = sender.tag
+        guard index < windows.count else { return }
+        onVisibilityToggled?(windows[index])
+    }
+
+    @objc private func ghostButtonTapped(_ sender: NSButton) {
+        let index = sender.tag
+        guard index < windows.count else { return }
+        onGhostToggled?(windows[index])
+    }
+}
+
+// MARK: - ManagementPanelRowView
+
+private final class ManagementPanelRowView: NSTableRowView {
+    private static let highlightAlpha: CGFloat = 0.2
+
+    var isHighlighted: Bool = false {
+        didSet { needsDisplay = true }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        if isHighlighted {
+            NSColor.selectedContentBackgroundColor.withAlphaComponent(Self.highlightAlpha).setFill()
+            bounds.fill()
+        }
+    }
+}


### PR DESCRIPTION
## 概要

- `ManagementPanelWindowListView`: NSTableViewベースのウィンドウリスト（表示名、👁表示/非表示、👻ゴーストモードボタン）
- `ManagementPanelDetailView`: 画像プレビュー、不透明度スライダー、ゴースト/表示スイッチ
- `ManagementPanelDelegate`: ウィンドウ操作メソッド3つ + `managedWindows` プロパティ
- ステータスバーに「N/M 表示中」を表示

## テスト計画

- [x] `./build.sh` — SwiftLint含め正常ビルド
- [x] `xcodebuild test` — 全632テストパス
- [x] `/simplify` レビュー実施、型行数制限対応・マジックナンバー定数化済み

Closes #30