### PR TITLE
feat: 管理パネル Phase 5 — レイヤー順序変更 + D&D

### DIFF
--- a/Sobani.xcodeproj/project.pbxproj
+++ b/Sobani.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		F0MP000004000000000001 /* ManagementPanelController+Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0MP000003000000000001 /* ManagementPanelController+Setup.swift */; };
 		F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */; };
 		F0WL000002000000000001 /* ManagementPanelWindowListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0WL000001000000000001 /* ManagementPanelWindowListView.swift */; };
+		F0WL000004000000000001 /* ManagementPanelWindowListView+DragDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0WL000003000000000001 /* ManagementPanelWindowListView+DragDrop.swift */; };
 		F0DV000002000000000001 /* ManagementPanelDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DV000001000000000001 /* ManagementPanelDetailView.swift */; };
 /* End PBXBuildFile section */
 
@@ -220,6 +221,7 @@
 		F0MP000003000000000001 /* ManagementPanelController+Setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagementPanelController+Setup.swift"; sourceTree = "<group>"; };
 		F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ManagementPanel.swift"; sourceTree = "<group>"; };
 		F0WL000001000000000001 /* ManagementPanelWindowListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelWindowListView.swift; sourceTree = "<group>"; };
+		F0WL000003000000000001 /* ManagementPanelWindowListView+DragDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagementPanelWindowListView+DragDrop.swift"; sourceTree = "<group>"; };
 		F0DV000001000000000001 /* ManagementPanelDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelDetailView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -301,6 +303,7 @@
 				F0MP000001000000000001 /* ManagementPanelController.swift */,
 				F0MP000003000000000001 /* ManagementPanelController+Setup.swift */,
 				F0WL000001000000000001 /* ManagementPanelWindowListView.swift */,
+				F0WL000003000000000001 /* ManagementPanelWindowListView+DragDrop.swift */,
 				F0DV000001000000000001 /* ManagementPanelDetailView.swift */,
 				F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */,
 				F0JP000001000000000001 /* JSONPersistence.swift */,
@@ -536,6 +539,7 @@
 				F0MP000002000000000001 /* ManagementPanelController.swift in Sources */,
 				F0MP000004000000000001 /* ManagementPanelController+Setup.swift in Sources */,
 				F0WL000002000000000001 /* ManagementPanelWindowListView.swift in Sources */,
+				F0WL000004000000000001 /* ManagementPanelWindowListView+DragDrop.swift in Sources */,
 				F0DV000002000000000001 /* ManagementPanelDetailView.swift in Sources */,
 				F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */,
 				F0JP000002000000000001 /* JSONPersistence.swift in Sources */,

--- a/Sobani/AppDelegate+ManagementPanel.swift
+++ b/Sobani/AppDelegate+ManagementPanel.swift
@@ -42,4 +42,12 @@ extension AppDelegate: ManagementPanelDelegate {
     func managementPanel(_ panel: ManagementPanelController, didChangeOpacity opacity: CGFloat, for charWindow: CharacterWindow) {
         charWindow.applyOpacity(opacity)
     }
+
+    func managementPanel(_ panel: ManagementPanelController, didReorderWindow charWindow: CharacterWindow, to index: Int) {
+        guard let currentIndex = zOrderedWindows.firstIndex(where: { $0 === charWindow }) else { return }
+        zOrderedWindows.remove(at: currentIndex)
+        let safeIndex = max(0, min(index, zOrderedWindows.count))
+        zOrderedWindows.insert(charWindow, at: safeIndex)
+        applyZOrderToWindows()
+    }
 }

--- a/Sobani/ManagementPanelController+Setup.swift
+++ b/Sobani/ManagementPanelController+Setup.swift
@@ -28,6 +28,11 @@ extension ManagementPanelController {
             delegate.managementPanel(self, didToggleGhostMode: charWindow)
             self.reloadWindowList()
         }
+        listView.onReorder = { [weak self] charWindow, newIndex in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didReorderWindow: charWindow, to: newIndex)
+            self.reloadWindowList()
+        }
         container.addSubview(listView)
         windowListView = listView
 

--- a/Sobani/ManagementPanelController.swift
+++ b/Sobani/ManagementPanelController.swift
@@ -9,6 +9,7 @@ protocol ManagementPanelDelegate: AnyObject {
     func managementPanel(_ panel: ManagementPanelController, didToggleVisibility charWindow: CharacterWindow)
     func managementPanel(_ panel: ManagementPanelController, didToggleGhostMode charWindow: CharacterWindow)
     func managementPanel(_ panel: ManagementPanelController, didChangeOpacity opacity: CGFloat, for charWindow: CharacterWindow)
+    func managementPanel(_ panel: ManagementPanelController, didReorderWindow charWindow: CharacterWindow, to index: Int)
 }
 
 // MARK: - ManagementPanelController

--- a/Sobani/ManagementPanelWindowListView+DragDrop.swift
+++ b/Sobani/ManagementPanelWindowListView+DragDrop.swift
@@ -1,0 +1,47 @@
+import Cocoa
+
+// MARK: - Drag & Drop Setup
+
+extension ManagementPanelWindowListView {
+    func setupDragDrop() {
+        listTableView?.registerForDraggedTypes([.string])
+        listTableView?.draggingDestinationFeedbackStyle = .gap
+    }
+}
+
+// MARK: - NSTableViewDataSource (Drag & Drop)
+
+extension ManagementPanelWindowListView {
+    func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> (any NSPasteboardWriting)? {
+        let item = NSPasteboardItem()
+        item.setString(String(row), forType: .string)
+        return item
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        validateDrop info: any NSDraggingInfo,
+        proposedRow row: Int,
+        proposedDropOperation dropOperation: NSTableView.DropOperation
+    ) -> NSDragOperation {
+        guard dropOperation == .above else { return [] }
+        return .move
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        acceptDrop info: any NSDraggingInfo,
+        row: Int,
+        dropOperation: NSTableView.DropOperation
+    ) -> Bool {
+        guard let item = info.draggingPasteboard.pasteboardItems?.first,
+              let sourceRowStr = item.string(forType: .string),
+              let sourceRow = Int(sourceRowStr) else { return false }
+        guard sourceRow != row, sourceRow != row - 1 else { return false }
+        guard sourceRow < windows.count else { return false }
+        let charWindow = windows[sourceRow]
+        let destRow = sourceRow < row ? row - 1 : row
+        onReorder?(charWindow, destRow)
+        return true
+    }
+}

--- a/Sobani/ManagementPanelWindowListView.swift
+++ b/Sobani/ManagementPanelWindowListView.swift
@@ -16,9 +16,15 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
     private static let eyeButtonX: CGFloat = 132
     private static let ghostButtonX: CGFloat = 160
     private static let actionButtonSize: CGFloat = 24
+    private static let upButtonX: CGFloat = 192
+    private static let downButtonX: CGFloat = 216
+    private static let reorderButtonY: CGFloat = 10
+    private static let reorderButtonWidth: CGFloat = 20
+    private static let reorderButtonHeight: CGFloat = 24
+    private static let reorderButtonIconPointSize: CGFloat = 11
 
     private let logger = Logger(category: "ManagementPanelWindowListView")
-    private var tableView: NSTableView?
+    var listTableView: NSTableView?
     private var scrollView: NSScrollView?
     private(set) var windows: [CharacterWindow] = []
     private(set) var selectedWindow: CharacterWindow?
@@ -69,19 +75,20 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
         table.addTableColumn(column)
 
         scroll.documentView = table
-        tableView = table
+        listTableView = table
+        setupDragDrop()
     }
 
     // MARK: - Public API
 
     func reload(with windows: [CharacterWindow]) {
         self.windows = windows
-        tableView?.reloadData()
+        listTableView?.reloadData()
     }
 
     func selectWindow(_ charWindow: CharacterWindow?) {
         selectedWindow = charWindow
-        guard let table = tableView else { return }
+        guard let table = listTableView else { return }
         if let charWindow, let index = windows.firstIndex(where: { $0 === charWindow }) {
             table.selectRowIndexes(IndexSet(integer: index), byExtendingSelection: false)
         } else {
@@ -126,7 +133,7 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
     }
 
     func tableViewSelectionDidChange(_ notification: Notification) {
-        guard let table = tableView else { return }
+        guard let table = listTableView else { return }
         let row = table.selectedRow
         if row >= 0, row < windows.count {
             selectedWindow = windows[row]
@@ -140,6 +147,12 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
     // MARK: - Cell Building
 
     private func buildCellContent(in cellView: NSView, charWindow: CharacterWindow, index: Int) {
+        buildCellLabels(in: cellView, charWindow: charWindow, index: index)
+        buildCellActionButtons(in: cellView, charWindow: charWindow, index: index)
+        buildCellReorderButtons(in: cellView, index: index)
+    }
+
+    private func buildCellLabels(in cellView: NSView, charWindow: CharacterWindow, index: Int) {
         let rowHeight = AppConstants.managementPanelRowHeight
 
         // Index label
@@ -177,6 +190,10 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
             height: Self.idLabelHeight
         )
         cellView.addSubview(idLabel)
+    }
+
+    private func buildCellActionButtons(in cellView: NSView, charWindow: CharacterWindow, index: Int) {
+        let rowHeight = AppConstants.managementPanelRowHeight
 
         // Eye button (visibility toggle)
         let eyeSymbol = charWindow.isHidden ? AppConstants.hiddenWindowSymbol : AppConstants.visibleWindowSymbol
@@ -206,15 +223,47 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
         ghostButton.isBordered = false
         ghostButton.imagePosition = .imageOnly
         ghostButton.image = SFSymbolUtils.icon(AppConstants.ghostModeSymbol, pointSize: 14, weight: .regular)
-        if charWindow.isGhostMode {
-            ghostButton.contentTintColor = .controlAccentColor
-        } else {
-            ghostButton.contentTintColor = nil
-        }
+        ghostButton.contentTintColor = charWindow.isGhostMode ? .controlAccentColor : nil
         ghostButton.tag = index
         ghostButton.target = self
         ghostButton.action = #selector(ghostButtonTapped(_:))
         cellView.addSubview(ghostButton)
+    }
+
+    private func buildCellReorderButtons(in cellView: NSView, index: Int) {
+        // Up button (move layer up)
+        let upButton = NSButton(frame: NSRect(
+            x: Self.upButtonX,
+            y: Self.reorderButtonY,
+            width: Self.reorderButtonWidth,
+            height: Self.reorderButtonHeight
+        ))
+        upButton.bezelStyle = .regularSquare
+        upButton.isBordered = false
+        upButton.imagePosition = .imageOnly
+        upButton.image = SFSymbolUtils.icon("chevron.up", pointSize: Self.reorderButtonIconPointSize, weight: .regular)
+        upButton.tag = index
+        upButton.isEnabled = index > 0
+        upButton.target = self
+        upButton.action = #selector(moveUpButtonTapped(_:))
+        cellView.addSubview(upButton)
+
+        // Down button (move layer down)
+        let downButton = NSButton(frame: NSRect(
+            x: Self.downButtonX,
+            y: Self.reorderButtonY,
+            width: Self.reorderButtonWidth,
+            height: Self.reorderButtonHeight
+        ))
+        downButton.bezelStyle = .regularSquare
+        downButton.isBordered = false
+        downButton.imagePosition = .imageOnly
+        downButton.image = SFSymbolUtils.icon("chevron.down", pointSize: Self.reorderButtonIconPointSize, weight: .regular)
+        downButton.tag = index
+        downButton.isEnabled = index < windows.count - 1
+        downButton.target = self
+        downButton.action = #selector(moveDownButtonTapped(_:))
+        cellView.addSubview(downButton)
     }
 
     // MARK: - Actions
@@ -229,6 +278,18 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
         let index = sender.tag
         guard index < windows.count else { return }
         onGhostToggled?(windows[index])
+    }
+
+    @objc private func moveUpButtonTapped(_ sender: NSButton) {
+        let index = sender.tag
+        guard index > 0, index < windows.count else { return }
+        onReorder?(windows[index], index - 1)
+    }
+
+    @objc private func moveDownButtonTapped(_ sender: NSButton) {
+        let index = sender.tag
+        guard index >= 0, index < windows.count - 1 else { return }
+        onReorder?(windows[index], index + 1)
     }
 }
 


### PR DESCRIPTION
## 概要

- ウィンドウリスト各行に↑↓ボタン追加（先頭/末尾は自動無効化）
- NSTableView ドラッグ&ドロップで行の並替え対応
- `ManagementPanelDelegate.didReorderWindow` で zOrderedWindows を更新

## テスト計画

- [x] `./build.sh` — SwiftLint含め正常ビルド
- [x] `xcodebuild test` — 全88テストパス
- [x] `/simplify` レビュー実施

Closes #31