### PR TITLE
feat: 管理パネル Phase 6 — 一括操作

### DIFF
--- a/Sobani/AppDelegate+ManagementPanel.swift
+++ b/Sobani/AppDelegate+ManagementPanel.swift
@@ -50,4 +50,30 @@ extension AppDelegate: ManagementPanelDelegate {
         zOrderedWindows.insert(charWindow, at: safeIndex)
         applyZOrderToWindows()
     }
+
+    func managementPanelDidRequestShowAll(_ panel: ManagementPanelController) {
+        areWindowsHidden = false
+        for charWindow in zOrderedWindows where charWindow.isHidden {
+            charWindow.setHidden(false)
+        }
+        applyZOrderToWindows()
+    }
+
+    func managementPanelDidRequestHideAll(_ panel: ManagementPanelController) {
+        for charWindow in zOrderedWindows {
+            charWindow.setHidden(true)
+            charWindow.window.orderOut(nil)
+        }
+        areWindowsHidden = true
+    }
+
+    func managementPanelDidRequestGhostAll(_ panel: ManagementPanelController) {
+        for charWindow in zOrderedWindows {
+            charWindow.setGhostMode(true)
+        }
+    }
+
+    func managementPanelDidRequestUnghostAll(_ panel: ManagementPanelController) {
+        disableAllGhostMode()
+    }
 }

--- a/Sobani/Localizable.xcstrings
+++ b/Sobani/Localizable.xcstrings
@@ -3760,6 +3760,70 @@
           }
         }
       }
+    },
+    "management.show_all": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全表示"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show All"
+          }
+        }
+      }
+    },
+    "management.hide_all": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全非表示"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide All"
+          }
+        }
+      }
+    },
+    "management.ghost_all": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "全Ghost"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghost All"
+          }
+        }
+      }
+    },
+    "management.unghost_all": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ghost解除"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unghost"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sobani/ManagementPanelController+Setup.swift
+++ b/Sobani/ManagementPanelController+Setup.swift
@@ -33,6 +33,9 @@ extension ManagementPanelController {
             delegate.managementPanel(self, didReorderWindow: charWindow, to: newIndex)
             self.reloadWindowList()
         }
+        listView.onBulkAction = { [weak self] action in
+            self?.handleBulkAction(action)
+        }
         container.addSubview(listView)
         windowListView = listView
 
@@ -62,6 +65,21 @@ extension ManagementPanelController {
         }
         container.addSubview(detail)
         detailView = detail
+    }
+
+    private func handleBulkAction(_ action: ManagementPanelWindowListView.BulkAction) {
+        guard let delegate else { return }
+        switch action {
+        case .showAll:
+            delegate.managementPanelDidRequestShowAll(self)
+        case .hideAll:
+            delegate.managementPanelDidRequestHideAll(self)
+        case .ghostAll:
+            delegate.managementPanelDidRequestGhostAll(self)
+        case .unghostAll:
+            delegate.managementPanelDidRequestUnghostAll(self)
+        }
+        reloadWindowList()
     }
 
     func reloadWindowList() {

--- a/Sobani/ManagementPanelController.swift
+++ b/Sobani/ManagementPanelController.swift
@@ -10,6 +10,10 @@ protocol ManagementPanelDelegate: AnyObject {
     func managementPanel(_ panel: ManagementPanelController, didToggleGhostMode charWindow: CharacterWindow)
     func managementPanel(_ panel: ManagementPanelController, didChangeOpacity opacity: CGFloat, for charWindow: CharacterWindow)
     func managementPanel(_ panel: ManagementPanelController, didReorderWindow charWindow: CharacterWindow, to index: Int)
+    func managementPanelDidRequestShowAll(_ panel: ManagementPanelController)
+    func managementPanelDidRequestHideAll(_ panel: ManagementPanelController)
+    func managementPanelDidRequestGhostAll(_ panel: ManagementPanelController)
+    func managementPanelDidRequestUnghostAll(_ panel: ManagementPanelController)
 }
 
 // MARK: - ManagementPanelController

--- a/Sobani/ManagementPanelWindowListView.swift
+++ b/Sobani/ManagementPanelWindowListView.swift
@@ -22,6 +22,14 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
     private static let reorderButtonWidth: CGFloat = 20
     private static let reorderButtonHeight: CGFloat = 24
     private static let reorderButtonIconPointSize: CGFloat = 11
+    private static let bulkBarHeight: CGFloat = AppConstants.managementPanelBulkBarHeight
+    private static let bulkButtonShowAllX: CGFloat = 8
+    private static let bulkButtonHideAllX: CGFloat = 66
+    private static let bulkButtonGhostAllX: CGFloat = 124
+    private static let bulkButtonUnghostAllX: CGFloat = 182
+    private static let bulkButtonY: CGFloat = 6
+    private static let bulkButtonWidth: CGFloat = 54
+    private static let bulkButtonHeight: CGFloat = 28
 
     private let logger = Logger(category: "ManagementPanelWindowListView")
     var listTableView: NSTableView?
@@ -55,7 +63,9 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
     // MARK: - Setup
 
     private func setupTableView() {
-        let scroll = NSScrollView(frame: bounds)
+        let bulkBarHeight = Self.bulkBarHeight
+        let scrollFrame = NSRect(x: 0, y: bulkBarHeight, width: bounds.width, height: bounds.height - bulkBarHeight)
+        let scroll = NSScrollView(frame: scrollFrame)
         scroll.autoresizingMask = [.width, .height]
         scroll.hasVerticalScroller = true
         scroll.borderType = .noBorder
@@ -77,6 +87,42 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
         scroll.documentView = table
         listTableView = table
         setupDragDrop()
+        setupBulkActionBar()
+    }
+
+    private struct BulkButtonSpec {
+        let label: String
+        let action: Selector
+        let xPosition: CGFloat
+    }
+
+    private func setupBulkActionBar() {
+        let barFrame = NSRect(x: 0, y: 0, width: bounds.width, height: Self.bulkBarHeight)
+        let bar = NSView(frame: barFrame)
+        bar.autoresizingMask = [.width]
+        addSubview(bar)
+
+        let specs = [
+            BulkButtonSpec(label: L("management.show_all"), action: #selector(showAllTapped), xPosition: Self.bulkButtonShowAllX),
+            BulkButtonSpec(label: L("management.hide_all"), action: #selector(hideAllTapped), xPosition: Self.bulkButtonHideAllX),
+            BulkButtonSpec(label: L("management.ghost_all"), action: #selector(ghostAllTapped), xPosition: Self.bulkButtonGhostAllX),
+            BulkButtonSpec(label: L("management.unghost_all"), action: #selector(unghostAllTapped), xPosition: Self.bulkButtonUnghostAllX)
+        ]
+
+        for spec in specs {
+            let button = NSButton(frame: NSRect(
+                x: spec.xPosition,
+                y: Self.bulkButtonY,
+                width: Self.bulkButtonWidth,
+                height: Self.bulkButtonHeight
+            ))
+            button.bezelStyle = .recessed
+            button.controlSize = .small
+            button.title = spec.label
+            button.target = self
+            button.action = spec.action
+            bar.addSubview(button)
+        }
     }
 
     // MARK: - Public API
@@ -290,6 +336,22 @@ final class ManagementPanelWindowListView: NSView, NSTableViewDataSource, NSTabl
         let index = sender.tag
         guard index >= 0, index < windows.count - 1 else { return }
         onReorder?(windows[index], index + 1)
+    }
+
+    @objc private func showAllTapped() {
+        onBulkAction?(.showAll)
+    }
+
+    @objc private func hideAllTapped() {
+        onBulkAction?(.hideAll)
+    }
+
+    @objc private func ghostAllTapped() {
+        onBulkAction?(.ghostAll)
+    }
+
+    @objc private func unghostAllTapped() {
+        onBulkAction?(.unghostAll)
     }
 }
 


### PR DESCRIPTION
## 概要

- ウィンドウリスト下部に一括操作バー（全表示/全非表示/全Ghost/Ghost解除）
- `ManagementPanelDelegate` に4つの一括操作メソッド追加
- AppDelegate で既存の一括操作ロジックと連携

## テスト計画

- [x] `./build.sh` — SwiftLint含め正常ビルド
- [x] `xcodebuild test` — 全632テストパス

Closes #32