### PR TITLE
feat: 管理パネル Phase 7 — レイアウトタブ

### DIFF
--- a/Sobani.xcodeproj/project.pbxproj
+++ b/Sobani.xcodeproj/project.pbxproj
@@ -106,6 +106,9 @@
 		F0WL000002000000000001 /* ManagementPanelWindowListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0WL000001000000000001 /* ManagementPanelWindowListView.swift */; };
 		F0WL000004000000000001 /* ManagementPanelWindowListView+DragDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0WL000003000000000001 /* ManagementPanelWindowListView+DragDrop.swift */; };
 		F0DV000002000000000001 /* ManagementPanelDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0DV000001000000000001 /* ManagementPanelDetailView.swift */; };
+		F0LV000002000000000001 /* ManagementPanelLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0LV000001000000000001 /* ManagementPanelLayoutView.swift */; };
+		F0LV000004000000000001 /* ManagementPanelLayoutView+Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0LV000003000000000001 /* ManagementPanelLayoutView+Setup.swift */; };
+		F0LV000006000000000001 /* ManagementPanelLayoutView+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0LV000005000000000001 /* ManagementPanelLayoutView+Cells.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -223,6 +226,9 @@
 		F0WL000001000000000001 /* ManagementPanelWindowListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelWindowListView.swift; sourceTree = "<group>"; };
 		F0WL000003000000000001 /* ManagementPanelWindowListView+DragDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagementPanelWindowListView+DragDrop.swift"; sourceTree = "<group>"; };
 		F0DV000001000000000001 /* ManagementPanelDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelDetailView.swift; sourceTree = "<group>"; };
+		F0LV000001000000000001 /* ManagementPanelLayoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelLayoutView.swift; sourceTree = "<group>"; };
+		F0LV000003000000000001 /* ManagementPanelLayoutView+Setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagementPanelLayoutView+Setup.swift"; sourceTree = "<group>"; };
+		F0LV000005000000000001 /* ManagementPanelLayoutView+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagementPanelLayoutView+Cells.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -305,6 +311,9 @@
 				F0WL000001000000000001 /* ManagementPanelWindowListView.swift */,
 				F0WL000003000000000001 /* ManagementPanelWindowListView+DragDrop.swift */,
 				F0DV000001000000000001 /* ManagementPanelDetailView.swift */,
+				F0LV000001000000000001 /* ManagementPanelLayoutView.swift */,
+				F0LV000003000000000001 /* ManagementPanelLayoutView+Setup.swift */,
+				F0LV000005000000000001 /* ManagementPanelLayoutView+Cells.swift */,
 				F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */,
 				F0JP000001000000000001 /* JSONPersistence.swift */,
 				F0NP000001000000000001 /* NSPanel+FloatingConfig.swift */,
@@ -541,6 +550,9 @@
 				F0WL000002000000000001 /* ManagementPanelWindowListView.swift in Sources */,
 				F0WL000004000000000001 /* ManagementPanelWindowListView+DragDrop.swift in Sources */,
 				F0DV000002000000000001 /* ManagementPanelDetailView.swift in Sources */,
+				F0LV000002000000000001 /* ManagementPanelLayoutView.swift in Sources */,
+				F0LV000004000000000001 /* ManagementPanelLayoutView+Setup.swift in Sources */,
+				F0LV000006000000000001 /* ManagementPanelLayoutView+Cells.swift in Sources */,
 				F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */,
 				F0JP000002000000000001 /* JSONPersistence.swift in Sources */,
 				F0NP000002000000000001 /* NSPanel+FloatingConfig.swift in Sources */,

--- a/Sobani/AppDelegate+ManagementPanel.swift
+++ b/Sobani/AppDelegate+ManagementPanel.swift
@@ -76,4 +76,35 @@ extension AppDelegate: ManagementPanelDelegate {
     func managementPanelDidRequestUnghostAll(_ panel: ManagementPanelController) {
         disableAllGhostMode()
     }
+
+    func managementPanel(_ panel: ManagementPanelController, didRequestApplyLayout preset: LayoutPreset) {
+        applyLayout(preset)
+        panel.reloadWindowList()
+    }
+
+    func managementPanel(_ panel: ManagementPanelController, didRequestSaveLayoutWithName name: String) {
+        let states = captureCurrentWindowStates()
+        LayoutPresetManager.shared.savePreset(name: name, states: states)
+    }
+
+    func managementPanelDidRequestCreateNewLayout(_ panel: ManagementPanelController) {
+        createNewLayoutFromMenu()
+    }
+
+    func managementPanel(_ panel: ManagementPanelController, didRequestUpdateLayout preset: LayoutPreset) {
+        let states = captureCurrentWindowStates()
+        LayoutPresetManager.shared.savePreset(name: preset.name, states: states)
+    }
+
+    func managementPanel(_ panel: ManagementPanelController, didRequestDeleteLayout preset: LayoutPreset) {
+        LayoutPresetManager.shared.deletePreset(named: preset.name)
+    }
+
+    func managementPanel(
+        _ panel: ManagementPanelController,
+        didRequestRenameLayout preset: LayoutPreset,
+        to newName: String
+    ) {
+        _ = LayoutPresetManager.shared.renamePreset(from: preset.name, to: newName)
+    }
 }

--- a/Sobani/Localizable.xcstrings
+++ b/Sobani/Localizable.xcstrings
@@ -3824,6 +3824,150 @@
           }
         }
       }
+    },
+    "management.select_preset": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プリセットを選択してください"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select a preset"
+          }
+        }
+      }
+    },
+    "management.save_layout": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+保存"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+Save"
+          }
+        }
+      }
+    },
+    "management.new_layout": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+新規"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+New"
+          }
+        }
+      }
+    },
+    "management.apply_layout": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apply"
+          }
+        }
+      }
+    },
+    "management.update_layout": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Update"
+          }
+        }
+      }
+    },
+    "management.rename_layout": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前変更"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
+          }
+        }
+      }
+    },
+    "management.delete_layout": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        }
+      }
+    },
+    "management.window_count_format": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ウィンドウ: %d"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Windows: %d"
+          }
+        }
+      }
+    },
+    "management.created_at_format": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Created: %@"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sobani/ManagementPanelController+Setup.swift
+++ b/Sobani/ManagementPanelController+Setup.swift
@@ -82,6 +82,46 @@ extension ManagementPanelController {
         reloadWindowList()
     }
 
+    func setupLayoutView() {
+        guard let container = contentContainer else { return }
+        let contentHeight = AppConstants.managementPanelContentHeight
+        let contentWidth = AppConstants.managementPanelContentWidth
+
+        let view = ManagementPanelLayoutView(frame: NSRect(
+            x: 0, y: 0, width: contentWidth, height: contentHeight
+        ))
+        view.onApplyLayout = { [weak self] preset in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didRequestApplyLayout: preset)
+            self.reloadWindowList()
+        }
+        view.onSaveLayout = { [weak self] name in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didRequestSaveLayoutWithName: name)
+        }
+        view.onCreateNewLayout = { [weak self] in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanelDidRequestCreateNewLayout(self)
+            self.reloadWindowList()
+            self.layoutView?.reloadPresets()
+        }
+        view.onUpdateLayout = { [weak self] preset in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didRequestUpdateLayout: preset)
+        }
+        view.onDeleteLayout = { [weak self] preset in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didRequestDeleteLayout: preset)
+        }
+        view.onRenameLayout = { [weak self] preset, newName in
+            guard let self, let delegate = self.delegate else { return }
+            delegate.managementPanel(self, didRequestRenameLayout: preset, to: newName)
+        }
+        container.addSubview(view)
+        layoutView = view
+        view.reloadPresets()
+    }
+
     func reloadWindowList() {
         guard let delegate else { return }
         let windows = delegate.managedWindows

--- a/Sobani/ManagementPanelController.swift
+++ b/Sobani/ManagementPanelController.swift
@@ -14,6 +14,12 @@ protocol ManagementPanelDelegate: AnyObject {
     func managementPanelDidRequestHideAll(_ panel: ManagementPanelController)
     func managementPanelDidRequestGhostAll(_ panel: ManagementPanelController)
     func managementPanelDidRequestUnghostAll(_ panel: ManagementPanelController)
+    func managementPanel(_ panel: ManagementPanelController, didRequestApplyLayout preset: LayoutPreset)
+    func managementPanel(_ panel: ManagementPanelController, didRequestSaveLayoutWithName name: String)
+    func managementPanelDidRequestCreateNewLayout(_ panel: ManagementPanelController)
+    func managementPanel(_ panel: ManagementPanelController, didRequestUpdateLayout preset: LayoutPreset)
+    func managementPanel(_ panel: ManagementPanelController, didRequestDeleteLayout preset: LayoutPreset)
+    func managementPanel(_ panel: ManagementPanelController, didRequestRenameLayout preset: LayoutPreset, to newName: String)
 }
 
 // MARK: - ManagementPanelController
@@ -58,6 +64,7 @@ final class ManagementPanelController: NSObject {
     weak var delegate: ManagementPanelDelegate?
     var windowListView: ManagementPanelWindowListView?
     var detailView: ManagementPanelDetailView?
+    var layoutView: ManagementPanelLayoutView?
 
     var isVisible: Bool { panel?.isVisible ?? false }
 
@@ -213,8 +220,13 @@ final class ManagementPanelController: NSObject {
         activeTab = tab
         contentContainer?.subviews.forEach { $0.removeFromSuperview() }
         updateSidebarHighlight(tab)
-        if tab == .windowManagement {
+        switch tab {
+        case .windowManagement:
             setupContentViews()
+        case .layout:
+            setupLayoutView()
+        case .settings:
+            break
         }
         updateStatusBar()
     }

--- a/Sobani/ManagementPanelLayoutView+Cells.swift
+++ b/Sobani/ManagementPanelLayoutView+Cells.swift
@@ -1,0 +1,76 @@
+import Cocoa
+
+// MARK: - ManagementPanelLayoutView + Cell Building
+
+extension ManagementPanelLayoutView {
+
+    func buildPresetCell(for row: Int) -> NSView? {
+        guard row < presets.count else { return nil }
+        let preset = presets[row]
+
+        let identifier = NSUserInterfaceItemIdentifier("PresetCell")
+        let cellView: NSView
+        if let reused = presetTableView?.makeView(withIdentifier: identifier, owner: self) {
+            cellView = reused
+            cellView.subviews.forEach { $0.removeFromSuperview() }
+        } else {
+            cellView = NSView()
+            cellView.identifier = identifier
+        }
+
+        let nameLabel = NSTextField(labelWithString: preset.name)
+        nameLabel.font = .systemFont(ofSize: 13)
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.frame = NSRect(x: 8, y: 26, width: Self.leftPaneWidth - 16, height: 16)
+        cellView.addSubview(nameLabel)
+
+        let windowCount = preset.states.count
+        let dateStr = shortDateString(from: preset.createdAt)
+        let infoText = "\(windowCount)件 • \(dateStr)"
+        let infoLabel = NSTextField(labelWithString: infoText)
+        infoLabel.font = .systemFont(ofSize: 10)
+        infoLabel.textColor = .secondaryLabelColor
+        infoLabel.lineBreakMode = .byTruncatingTail
+        infoLabel.frame = NSRect(x: 8, y: 8, width: Self.leftPaneWidth - 16, height: 14)
+        cellView.addSubview(infoLabel)
+
+        return cellView
+    }
+
+    func buildWindowStateCell(for row: Int) -> NSView? {
+        guard let states = selectedPreset?.states, row < states.count else { return nil }
+        let state = states[row]
+
+        let identifier = NSUserInterfaceItemIdentifier("WindowStateCell")
+        let cellView: NSView
+        if let reused = windowStateTableView?.makeView(withIdentifier: identifier, owner: self) {
+            cellView = reused
+            cellView.subviews.forEach { $0.removeFromSuperview() }
+        } else {
+            cellView = NSView()
+            cellView.identifier = identifier
+        }
+
+        let indexLabel = NSTextField(labelWithString: "\(row + 1).")
+        indexLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+        indexLabel.textColor = .secondaryLabelColor
+        indexLabel.frame = NSRect(x: 4, y: 7, width: 20, height: 14)
+        cellView.addSubview(indexLabel)
+
+        let nameLabel = NSTextField(labelWithString: state.imageName)
+        nameLabel.font = .systemFont(ofSize: 11)
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.frame = NSRect(x: 28, y: 7, width: 160, height: 14)
+        cellView.addSubview(nameLabel)
+
+        let posText = String(format: "(%.0f, %.0f)", state.originX, state.originY)
+        let posLabel = NSTextField(labelWithString: posText)
+        posLabel.font = .monospacedDigitSystemFont(ofSize: 10, weight: .regular)
+        posLabel.textColor = .secondaryLabelColor
+        posLabel.alignment = .right
+        posLabel.frame = NSRect(x: 192, y: 7, width: 100, height: 14)
+        cellView.addSubview(posLabel)
+
+        return cellView
+    }
+}

--- a/Sobani/ManagementPanelLayoutView+Setup.swift
+++ b/Sobani/ManagementPanelLayoutView+Setup.swift
@@ -1,0 +1,288 @@
+import Cocoa
+
+// MARK: - ManagementPanelLayoutView + Setup
+
+extension ManagementPanelLayoutView {
+
+    // MARK: - View Setup
+
+    func setupView() {
+        setupLeftPane()
+        setupDivider()
+        setupRightPane()
+    }
+
+    func setupLeftPane() {
+        let leftWidth = Self.leftPaneWidth
+        let buttonBarHeight = Self.buttonBarHeight
+        let contentHeight = bounds.height - buttonBarHeight
+
+        let scrollFrame = NSRect(x: 0, y: buttonBarHeight, width: leftWidth, height: contentHeight)
+        let scroll = NSScrollView(frame: scrollFrame)
+        scroll.autoresizingMask = [.height]
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .noBorder
+        addSubview(scroll)
+        presetScrollView = scroll
+
+        let table = NSTableView(frame: scroll.bounds)
+        table.dataSource = self
+        table.delegate = self
+        table.rowHeight = Self.listRowHeight
+        table.selectionHighlightStyle = .regular
+        table.backgroundColor = .clear
+        table.headerView = nil
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("preset"))
+        column.width = leftWidth
+        table.addTableColumn(column)
+
+        scroll.documentView = table
+        presetTableView = table
+
+        setupButtonBar(height: buttonBarHeight, width: leftWidth)
+    }
+
+    func setupButtonBar(height: CGFloat, width: CGFloat) {
+        let barFrame = NSRect(x: 0, y: 0, width: width, height: height)
+        let bar = NSView(frame: barFrame)
+        bar.autoresizingMask = [.width]
+        addSubview(bar)
+
+        let saveButton = NSButton(frame: NSRect(
+            x: Self.saveButtonX,
+            y: Self.buttonBarButtonY,
+            width: Self.buttonBarButtonWidth,
+            height: Self.buttonBarButtonHeight
+        ))
+        saveButton.bezelStyle = .recessed
+        saveButton.controlSize = .small
+        saveButton.title = L("management.save_layout")
+        saveButton.target = self
+        saveButton.action = #selector(saveButtonTapped)
+        bar.addSubview(saveButton)
+
+        let newButton = NSButton(frame: NSRect(
+            x: Self.newButtonX,
+            y: Self.buttonBarButtonY,
+            width: Self.buttonBarButtonWidth,
+            height: Self.buttonBarButtonHeight
+        ))
+        newButton.bezelStyle = .recessed
+        newButton.controlSize = .small
+        newButton.title = L("management.new_layout")
+        newButton.target = self
+        newButton.action = #selector(newButtonTapped)
+        bar.addSubview(newButton)
+    }
+
+    func setupDivider() {
+        let leftWidth = Self.leftPaneWidth
+        let divider = NSBox(frame: NSRect(x: leftWidth, y: 0, width: 1, height: bounds.height))
+        divider.boxType = .separator
+        addSubview(divider)
+    }
+
+    func setupRightPane() {
+        let leftWidth = Self.leftPaneWidth
+        let rightX = leftWidth + 1
+        let rightWidth = bounds.width - rightX
+        let rightHeight = bounds.height
+
+        let pane = NSView(frame: NSRect(x: rightX, y: 0, width: rightWidth, height: rightHeight))
+        addSubview(pane)
+
+        let label = NSTextField(labelWithString: L("management.select_preset"))
+        label.font = .systemFont(ofSize: Self.detailLabelFontSize)
+        label.textColor = .secondaryLabelColor
+        label.alignment = .center
+        label.sizeToFit()
+        label.frame = NSRect(
+            x: (rightWidth - label.frame.width) / 2,
+            y: (rightHeight - label.frame.height) / 2,
+            width: label.frame.width,
+            height: label.frame.height
+        )
+        pane.addSubview(label)
+        emptyLabel = label
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: rightWidth, height: rightHeight))
+        container.isHidden = true
+        pane.addSubview(container)
+        detailContainer = container
+
+        setupDetailContent(in: container, width: rightWidth, height: rightHeight)
+    }
+
+    func setupDetailContent(in container: NSView, width: CGFloat, height: CGFloat) {
+        let padding = Self.detailPadding
+        let contentWidth = width - padding * 2
+
+        let nameLabel = NSTextField(labelWithString: "")
+        nameLabel.font = .systemFont(ofSize: Self.presetNameFontSize, weight: .semibold)
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.frame = NSRect(x: padding, y: height - padding - 22, width: contentWidth, height: 22)
+        container.addSubview(nameLabel)
+        presetNameLabel = nameLabel
+
+        let infoLabel = NSTextField(labelWithString: "")
+        infoLabel.font = .systemFont(ofSize: Self.detailSubLabelFontSize)
+        infoLabel.textColor = .secondaryLabelColor
+        infoLabel.frame = NSRect(x: padding, y: height - padding - 22 - 4 - 16, width: contentWidth, height: 16)
+        container.addSubview(infoLabel)
+        presetInfoLabel = infoLabel
+
+        let countLabel = NSTextField(labelWithString: "")
+        countLabel.font = .systemFont(ofSize: Self.detailSubLabelFontSize)
+        countLabel.textColor = .secondaryLabelColor
+        countLabel.frame = NSRect(x: padding, y: height - padding - 22 - 4 - 16 - 4 - 16, width: contentWidth, height: 16)
+        container.addSubview(countLabel)
+        windowCountLabel = countLabel
+
+        let listTopY = height - padding - 22 - 4 - 16 - 4 - 16 - 8
+        let actionBarHeight: CGFloat = Self.actionButtonHeight + Self.actionButtonY * 2
+        let listHeight = listTopY - actionBarHeight - padding
+        let listFrame = NSRect(x: padding, y: actionBarHeight + padding, width: contentWidth, height: listHeight)
+        setupWindowStateList(in: container, frame: listFrame)
+
+        setupActionButtons(in: container, y: Self.actionButtonY, padding: padding)
+    }
+
+    func setupWindowStateList(in container: NSView, frame: NSRect) {
+        let scroll = NSScrollView(frame: frame)
+        scroll.hasVerticalScroller = true
+        scroll.borderType = .lineBorder
+        container.addSubview(scroll)
+
+        let table = NSTableView(frame: scroll.bounds)
+        table.dataSource = self
+        table.delegate = self
+        table.rowHeight = Self.detailRowHeight
+        table.selectionHighlightStyle = .none
+        table.backgroundColor = .clear
+        table.headerView = nil
+        table.tag = 1
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("windowState"))
+        column.width = frame.width - 3
+        table.addTableColumn(column)
+
+        scroll.documentView = table
+        windowStateTableView = table
+    }
+
+    func setupActionButtons(in container: NSView, y: CGFloat, padding: CGFloat) {
+        struct ButtonSpec {
+            let key: String
+            let action: Selector
+        }
+        let specs: [ButtonSpec] = [
+            ButtonSpec(key: "management.apply_layout", action: #selector(applyButtonTapped)),
+            ButtonSpec(key: "management.update_layout", action: #selector(updateButtonTapped)),
+            ButtonSpec(key: "management.rename_layout", action: #selector(renameButtonTapped)),
+            ButtonSpec(key: "management.delete_layout", action: #selector(deleteButtonTapped))
+        ]
+        var buttons: [NSButton] = []
+        var currentX = padding
+        for spec in specs {
+            let button = NSButton(frame: NSRect(
+                x: currentX, y: y,
+                width: Self.actionButtonWidth,
+                height: Self.actionButtonHeight
+            ))
+            button.bezelStyle = .recessed
+            button.controlSize = .small
+            button.title = L(spec.key)
+            button.target = self
+            button.action = spec.action
+            container.addSubview(button)
+            buttons.append(button)
+            currentX += Self.actionButtonWidth + Self.actionButtonSpacing
+        }
+        if buttons.count >= 4 {
+            applyButton = buttons[0]
+            updateButton = buttons[1]
+            renameButton = buttons[2]
+            deleteButton = buttons[3]
+        }
+    }
+
+    // MARK: - Detail Helpers
+
+    func updateDetailVisibility() {
+        let hasSelection = selectedPreset != nil
+        emptyLabel?.isHidden = hasSelection
+        detailContainer?.isHidden = !hasSelection
+    }
+
+    func updateDetailContent() {
+        guard let preset = selectedPreset else { return }
+        presetNameLabel?.stringValue = preset.name
+        let formatter = DateFormatter()
+        formatter.dateFormat = Self.shortDateFormat
+        let dateString = formatter.string(from: preset.createdAt)
+        presetInfoLabel?.stringValue = String(format: L("management.created_at_format"), dateString)
+        windowCountLabel?.stringValue = String(format: L("management.window_count_format"), preset.states.count)
+        windowStateTableView?.reloadData()
+    }
+
+    func shortDateString(from date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = Self.shortDateFormat
+        return formatter.string(from: date)
+    }
+
+    func selectPresetByName(_ name: String) {
+        guard let index = presets.firstIndex(where: { $0.name == name }) else { return }
+        presetTableView?.selectRowIndexes(IndexSet(integer: index), byExtendingSelection: false)
+        selectedPreset = presets[index]
+        windowStateTableView?.reloadData()
+        updateDetailVisibility()
+        updateDetailContent()
+    }
+
+    // MARK: - Dialog Helpers
+
+    func promptPresetName(
+        messageText: String,
+        informativeText: String,
+        okTitle: String,
+        initialValue: String = "",
+        checkOverwrite: Bool = true
+    ) -> String? {
+        let alert = AlertFactory.make(
+            style: .informational,
+            messageText: messageText,
+            informativeText: informativeText,
+            buttonTitles: [okTitle, L("quit.cancel")]
+        )
+        let textField = NSTextField(frame: NSRect(
+            x: 0, y: 0,
+            width: AppConstants.layoutDialogFieldWidth,
+            height: AppConstants.layoutDialogFieldHeight
+        ))
+        textField.placeholderString = L("layout.name_placeholder")
+        if !initialValue.isEmpty {
+            textField.stringValue = initialValue
+        }
+        alert.accessoryView = textField
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        let name = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty else { return nil }
+        if checkOverwrite {
+            guard confirmOverwriteIfNeeded(name: name) else { return nil }
+        }
+        return name
+    }
+
+    func confirmOverwriteIfNeeded(name: String) -> Bool {
+        guard LayoutPresetManager.shared.presetExists(named: name) else { return true }
+        let alert = AlertFactory.confirmation(
+            messageText: L("layout.overwrite_title"),
+            informativeText: String(format: L("layout.overwrite_message"), name),
+            okTitle: L("layout.overwrite_button"),
+            cancelTitle: L("quit.cancel")
+        )
+        return alert.runModal() == .alertFirstButtonReturn
+    }
+}

--- a/Sobani/ManagementPanelLayoutView.swift
+++ b/Sobani/ManagementPanelLayoutView.swift
@@ -1,0 +1,188 @@
+import Cocoa
+import os.log
+
+// MARK: - ManagementPanelLayoutView
+
+@MainActor
+final class ManagementPanelLayoutView: NSView, NSTableViewDataSource, NSTableViewDelegate {
+
+    // MARK: - Layout Constants
+
+    static let leftPaneWidth: CGFloat = AppConstants.managementPanelListWidth
+    static let buttonBarHeight: CGFloat = AppConstants.managementPanelBulkBarHeight
+    static let listRowHeight: CGFloat = AppConstants.managementPanelLayoutRowHeight
+    static let detailRowHeight: CGFloat = 28
+    static let saveButtonX: CGFloat = 8
+    static let newButtonX: CGFloat = 122
+    static let buttonBarButtonWidth: CGFloat = 110
+    static let buttonBarButtonHeight: CGFloat = 28
+    static let buttonBarButtonY: CGFloat = 6
+    static let detailLabelFontSize: CGFloat = 12
+    static let detailSubLabelFontSize: CGFloat = 10
+    static let actionButtonWidth: CGFloat = 72
+    static let actionButtonHeight: CGFloat = 26
+    static let actionButtonSpacing: CGFloat = 4
+    static let actionButtonY: CGFloat = 8
+    static let detailPadding: CGFloat = 12
+    static let presetNameFontSize: CGFloat = 14
+    static let shortDateFormat: String = "M/dd HH:mm"
+
+    // MARK: - Callbacks
+
+    var onApplyLayout: ((LayoutPreset) -> Void)?
+    var onSaveLayout: ((String) -> Void)?
+    var onCreateNewLayout: (() -> Void)?
+    var onUpdateLayout: ((LayoutPreset) -> Void)?
+    var onDeleteLayout: ((LayoutPreset) -> Void)?
+    var onRenameLayout: ((LayoutPreset, String) -> Void)?
+
+    // MARK: - Internal State
+
+    let logger = Logger(category: "ManagementPanelLayoutView")
+    var presets: [LayoutPreset] = []
+    var selectedPreset: LayoutPreset?
+
+    // Left pane
+    var presetTableView: NSTableView?
+    var presetScrollView: NSScrollView?
+
+    // Right pane
+    var emptyLabel: NSTextField?
+    var detailContainer: NSView?
+    var presetNameLabel: NSTextField?
+    var presetInfoLabel: NSTextField?
+    var windowCountLabel: NSTextField?
+    var windowStateTableView: NSTableView?
+    var applyButton: NSButton?
+    var updateButton: NSButton?
+    var renameButton: NSButton?
+    var deleteButton: NSButton?
+
+    // MARK: - Init
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    // MARK: - Public API
+
+    func reloadPresets() {
+        presets = LayoutPresetManager.shared.loadPresets()
+
+        if let selected = selectedPreset,
+           let updated = presets.first(where: { $0.name == selected.name }) {
+            selectedPreset = updated
+        } else {
+            selectedPreset = nil
+        }
+
+        presetTableView?.reloadData()
+        windowStateTableView?.reloadData()
+        updateDetailVisibility()
+        updateDetailContent()
+    }
+
+    // MARK: - NSTableViewDataSource
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        if tableView.tag == 1 {
+            return selectedPreset?.states.count ?? 0
+        }
+        return presets.count
+    }
+
+    // MARK: - NSTableViewDelegate
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        if tableView.tag == 1 {
+            return buildWindowStateCell(for: row)
+        }
+        return buildPresetCell(for: row)
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        guard let table = notification.object as? NSTableView,
+              table !== windowStateTableView else { return }
+        let row = table.selectedRow
+        if row >= 0, row < presets.count {
+            selectedPreset = presets[row]
+        } else {
+            selectedPreset = nil
+        }
+        windowStateTableView?.reloadData()
+        updateDetailVisibility()
+        updateDetailContent()
+    }
+
+    // MARK: - Actions
+
+    @objc func saveButtonTapped() {
+        guard let name = promptPresetName(
+            messageText: L("layout.save_title"),
+            informativeText: L("layout.save_message"),
+            okTitle: L("layout.save_button")
+        ) else { return }
+        onSaveLayout?(name)
+        reloadPresets()
+        selectPresetByName(name)
+    }
+
+    @objc func newButtonTapped() {
+        onCreateNewLayout?()
+    }
+
+    @objc func applyButtonTapped() {
+        guard let preset = selectedPreset else { return }
+        onApplyLayout?(preset)
+    }
+
+    @objc func updateButtonTapped() {
+        guard let preset = selectedPreset else { return }
+        let alert = AlertFactory.confirmation(
+            messageText: L("layout.overwrite_title"),
+            informativeText: String(format: L("layout.update_confirm_message"), preset.name),
+            okTitle: L("layout.overwrite_button"),
+            cancelTitle: L("quit.cancel")
+        )
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        onUpdateLayout?(preset)
+        reloadPresets()
+        selectPresetByName(preset.name)
+    }
+
+    @objc func renameButtonTapped() {
+        guard let preset = selectedPreset else { return }
+        guard let newName = promptPresetName(
+            messageText: L("layout.rename_title"),
+            informativeText: L("layout.rename_message"),
+            okTitle: L("layout.rename_button"),
+            initialValue: preset.name,
+            checkOverwrite: false
+        ) else { return }
+        guard newName != preset.name else { return }
+        guard confirmOverwriteIfNeeded(name: newName) else { return }
+        onRenameLayout?(preset, newName)
+        reloadPresets()
+        selectPresetByName(newName)
+    }
+
+    @objc func deleteButtonTapped() {
+        guard let preset = selectedPreset else { return }
+        let alert = AlertFactory.confirmation(
+            messageText: L("layout.delete_confirm_title"),
+            informativeText: String(format: L("layout.delete_confirm_message"), preset.name),
+            okTitle: L("layout.delete_button"),
+            cancelTitle: L("quit.cancel")
+        )
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        onDeleteLayout?(preset)
+        selectedPreset = nil
+        reloadPresets()
+    }
+}


### PR DESCRIPTION
## 概要

- `ManagementPanelLayoutView`: プリセット一覧 + 詳細の左右分割構成
- +保存/+新規ボタンでプリセット作成、適用/更新/名前変更/削除の操作ボタン
- `LayoutPresetManager` との連携（既存メソッドを delegate 経由で呼出）
- ウィンドウ状態リストでプリセット内容をプレビュー
- SwiftLint型300行制限対応で3ファイルに分割

## テスト計画

- [x] `./build.sh` — SwiftLint含め正常ビルド
- [x] `xcodebuild test` — 全632テストパス

Closes #33