### PR TITLE
feat: 管理パネル Phase 9 — ホットキーカスタマイズUI

### DIFF
--- a/Sobani.xcodeproj/project.pbxproj
+++ b/Sobani.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		F0LV000004000000000001 /* ManagementPanelLayoutView+Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0LV000003000000000001 /* ManagementPanelLayoutView+Setup.swift */; };
 		F0LV000006000000000001 /* ManagementPanelLayoutView+Cells.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0LV000005000000000001 /* ManagementPanelLayoutView+Cells.swift */; };
 		F0MSV00002000000000001 /* ManagementPanelSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0MSV00001000000000001 /* ManagementPanelSettingsView.swift */; };
+		F0HRV00002000000000001 /* HotkeyRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0HRV00001000000000001 /* HotkeyRecorderView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -231,6 +232,7 @@
 		F0LV000003000000000001 /* ManagementPanelLayoutView+Setup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagementPanelLayoutView+Setup.swift"; sourceTree = "<group>"; };
 		F0LV000005000000000001 /* ManagementPanelLayoutView+Cells.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ManagementPanelLayoutView+Cells.swift"; sourceTree = "<group>"; };
 		F0MSV00001000000000001 /* ManagementPanelSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagementPanelSettingsView.swift; sourceTree = "<group>"; };
+		F0HRV00001000000000001 /* HotkeyRecorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotkeyRecorderView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -317,6 +319,7 @@
 				F0LV000003000000000001 /* ManagementPanelLayoutView+Setup.swift */,
 				F0LV000005000000000001 /* ManagementPanelLayoutView+Cells.swift */,
 				F0MSV00001000000000001 /* ManagementPanelSettingsView.swift */,
+				F0HRV00001000000000001 /* HotkeyRecorderView.swift */,
 				F0AM000001000000000001 /* AppDelegate+ManagementPanel.swift */,
 				F0JP000001000000000001 /* JSONPersistence.swift */,
 				F0NP000001000000000001 /* NSPanel+FloatingConfig.swift */,
@@ -557,6 +560,7 @@
 				F0LV000004000000000001 /* ManagementPanelLayoutView+Setup.swift in Sources */,
 				F0LV000006000000000001 /* ManagementPanelLayoutView+Cells.swift in Sources */,
 				F0MSV00002000000000001 /* ManagementPanelSettingsView.swift in Sources */,
+				F0HRV00002000000000001 /* HotkeyRecorderView.swift in Sources */,
 				F0AM000002000000000001 /* AppDelegate+ManagementPanel.swift in Sources */,
 				F0JP000002000000000001 /* JSONPersistence.swift in Sources */,
 				F0NP000002000000000001 /* NSPanel+FloatingConfig.swift in Sources */,

--- a/Sobani/AppDelegate+ManagementPanel.swift
+++ b/Sobani/AppDelegate+ManagementPanel.swift
@@ -107,4 +107,8 @@ extension AppDelegate: ManagementPanelDelegate {
     ) {
         _ = LayoutPresetManager.shared.renamePreset(from: preset.name, to: newName)
     }
+
+    func managementPanelDidChangeHotkey(_ panel: ManagementPanelController) {
+        teardownAndRebuildHotkeyMonitors()
+    }
 }

--- a/Sobani/AppDelegate.swift
+++ b/Sobani/AppDelegate.swift
@@ -127,6 +127,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         areWindowsHidden.toggle()
     }
 
+    func teardownAndRebuildHotkeyMonitors() {
+        if let monitor = globalMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalMonitor = nil
+        }
+        if let monitor = localMonitor {
+            NSEvent.removeMonitor(monitor)
+            localMonitor = nil
+        }
+        setupHotkeyMonitors()
+    }
+
     func setupHotkeyMonitors() {
         globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { @Sendable [weak self] event in
             guard let self else { return }

--- a/Sobani/HotkeyRecorderView.swift
+++ b/Sobani/HotkeyRecorderView.swift
@@ -1,0 +1,205 @@
+import Cocoa
+import os.log
+
+// MARK: - HotkeyRecorderView
+
+/// ホットキー1行分の記録UIコンポーネント。
+@MainActor
+final class HotkeyRecorderView: NSView {
+
+    // MARK: - Layout Constants
+
+    private static let viewHeight: CGFloat = 24
+    private static let actionLabelWidth: CGFloat = 100
+    private static let actionLabelX: CGFloat = 0
+    private static let keyFieldX: CGFloat = 104
+    private static let keyFieldWidth: CGFloat = 80
+    private static let recordButtonX: CGFloat = 192
+    private static let recordButtonWidth: CGFloat = 60
+    private static let resetButtonX: CGFloat = 260
+    private static let resetButtonWidth: CGFloat = 60
+    private static let cornerRadius: CGFloat = 4
+    private static let borderWidth: CGFloat = 1
+    private static let fontSizeLabel: CGFloat = 13
+
+    // MARK: - Properties
+
+    private let action: HotkeyAction
+    private var keyDisplayField: NSTextField?
+    private var recordButton: NSButton?
+    private var resetButton: NSButton?
+    private var isRecording = false
+    nonisolated(unsafe) private var recordMonitor: Any?
+
+    private let logger = Logger(category: "HotkeyRecorderView")
+
+    var onHotkeyChanged: ((HotkeyAction, HotkeyBinding) -> Void)?
+
+    // MARK: - Init
+
+    init(action: HotkeyAction, frame: NSRect) {
+        self.action = action
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        if let monitor = recordMonitor {
+            NSEvent.removeMonitor(monitor)
+        }
+    }
+
+    // MARK: - Setup
+
+    private func setupView() {
+        let height = Self.viewHeight
+
+        // アクション名ラベル
+        let nameLabel = NSTextField(labelWithString: action.displayName)
+        nameLabel.frame = NSRect(x: Self.actionLabelX, y: 0, width: Self.actionLabelWidth, height: height)
+        nameLabel.font = .systemFont(ofSize: Self.fontSizeLabel)
+        addSubview(nameLabel)
+
+        // キー表示フィールド
+        let field = NSTextField(labelWithString: HotkeyManager.shared.binding(for: action).displayString)
+        field.frame = NSRect(x: Self.keyFieldX, y: 0, width: Self.keyFieldWidth, height: height)
+        field.font = .monospacedSystemFont(ofSize: Self.fontSizeLabel, weight: .regular)
+        field.alignment = .center
+        field.wantsLayer = true
+        field.layer?.borderWidth = Self.borderWidth
+        field.layer?.borderColor = NSColor.separatorColor.cgColor
+        field.layer?.cornerRadius = Self.cornerRadius
+        addSubview(field)
+        keyDisplayField = field
+
+        // 記録ボタン
+        let recBtn = NSButton(
+            frame: NSRect(x: Self.recordButtonX, y: 0, width: Self.recordButtonWidth, height: height)
+        )
+        recBtn.bezelStyle = .rounded
+        recBtn.title = L("management.record")
+        recBtn.target = self
+        recBtn.action = #selector(recordButtonTapped)
+        addSubview(recBtn)
+        recordButton = recBtn
+
+        // リセットボタン
+        let rstBtn = NSButton(
+            frame: NSRect(x: Self.resetButtonX, y: 0, width: Self.resetButtonWidth, height: height)
+        )
+        rstBtn.bezelStyle = .rounded
+        rstBtn.title = L("management.reset")
+        rstBtn.target = self
+        rstBtn.action = #selector(resetButtonTapped)
+        addSubview(rstBtn)
+        resetButton = rstBtn
+    }
+
+    // MARK: - Public API
+
+    func updateDisplay() {
+        keyDisplayField?.stringValue = HotkeyManager.shared.binding(for: action).displayString
+        setRecordingState(false)
+    }
+
+    // MARK: - Actions
+
+    @objc private func recordButtonTapped() {
+        if isRecording {
+            cancelRecording()
+        } else {
+            startRecording()
+        }
+    }
+
+    @objc private func resetButtonTapped() {
+        HotkeyManager.shared.resetBinding(for: action)
+        keyDisplayField?.stringValue = action.defaultBinding.displayString
+        setRecordingState(false)
+        onHotkeyChanged?(action, action.defaultBinding)
+    }
+
+    // MARK: - Recording
+
+    private func startRecording() {
+        setRecordingState(true)
+        keyDisplayField?.stringValue = L("hotkey.waiting")
+        keyDisplayField?.layer?.backgroundColor = NSColor.selectedContentBackgroundColor.withAlphaComponent(0.2).cgColor
+
+        let actionForBlock = action
+        recordMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
+            guard let self else { return event }
+            return self.handleKeyDown(event: event, action: actionForBlock)
+        }
+    }
+
+    private func handleKeyDown(event: NSEvent, action: HotkeyAction) -> NSEvent? {
+        // ESC → キャンセル（nilを返してパネルのESC処理を防ぐ）
+        if event.keyCode == AppConstants.escKeyCode {
+            cancelRecording()
+            return nil
+        }
+
+        let eventModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let requiredModifiers: NSEvent.ModifierFlags = [.command, .option, .control, .shift]
+        let hasModifier = !eventModifiers.isDisjoint(with: requiredModifiers)
+
+        guard hasModifier else {
+            logger.warning("\(L("hotkey.needs_modifier"))")
+            cancelRecording()
+            return nil
+        }
+
+        let binding = HotkeyBinding(keyCode: event.keyCode, modifierMask: eventModifiers.rawValue)
+
+        if HotkeyManager.shared.hasSystemConflict(binding) {
+            logger.warning("\(L("hotkey.conflict_system"))")
+            cancelRecording()
+            return nil
+        }
+
+        if HotkeyManager.shared.hasSobaniConflict(binding, excluding: action) {
+            logger.warning("\(L("hotkey.conflict_sobani"))")
+            cancelRecording()
+            return nil
+        }
+
+        // 記録成功
+        finishRecording(binding: binding)
+        return nil
+    }
+
+    private func cancelRecording() {
+        stopRecordMonitor()
+        setRecordingState(false)
+        keyDisplayField?.stringValue = HotkeyManager.shared.binding(for: action).displayString
+        keyDisplayField?.layer?.backgroundColor = nil
+    }
+
+    private func finishRecording(binding: HotkeyBinding) {
+        stopRecordMonitor()
+        setRecordingState(false)
+        keyDisplayField?.stringValue = binding.displayString
+        keyDisplayField?.layer?.backgroundColor = nil
+        onHotkeyChanged?(action, binding)
+    }
+
+    private func setRecordingState(_ recording: Bool) {
+        isRecording = recording
+        recordButton?.title = recording ? L("hotkey.waiting") : L("management.record")
+        if !recording {
+            keyDisplayField?.layer?.backgroundColor = nil
+        }
+    }
+
+    private func stopRecordMonitor() {
+        if let monitor = recordMonitor {
+            NSEvent.removeMonitor(monitor)
+            recordMonitor = nil
+        }
+    }
+}

--- a/Sobani/Localizable.xcstrings
+++ b/Sobani/Localizable.xcstrings
@@ -4160,6 +4160,70 @@
           }
         }
       }
+    },
+    "hotkey.waiting": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "入力待ち..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Waiting..."
+          }
+        }
+      }
+    },
+    "hotkey.conflict_system": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "システムショートカットと競合しています"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conflicts with system shortcut"
+          }
+        }
+      }
+    },
+    "hotkey.conflict_sobani": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "他のアクションと競合しています"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conflicts with another action"
+          }
+        }
+      }
+    },
+    "hotkey.needs_modifier": {
+      "localizations": {
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "修飾キー（⌘⌥⌃⇧）を含めてください"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include a modifier key"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Sobani/ManagementPanelController+Setup.swift
+++ b/Sobani/ManagementPanelController+Setup.swift
@@ -130,6 +130,11 @@ extension ManagementPanelController {
         let view = ManagementPanelSettingsView(frame: NSRect(
             x: 0, y: 0, width: contentWidth, height: contentHeight
         ))
+        view.onHotkeyChanged = { [weak self] action, binding in
+            HotkeyManager.shared.setBinding(binding, for: action)
+            guard let self else { return }
+            self.delegate?.managementPanelDidChangeHotkey(self)
+        }
         container.addSubview(view)
         settingsView = view
         view.syncWithCurrentSettings()

--- a/Sobani/ManagementPanelController.swift
+++ b/Sobani/ManagementPanelController.swift
@@ -20,6 +20,7 @@ protocol ManagementPanelDelegate: AnyObject {
     func managementPanel(_ panel: ManagementPanelController, didRequestUpdateLayout preset: LayoutPreset)
     func managementPanel(_ panel: ManagementPanelController, didRequestDeleteLayout preset: LayoutPreset)
     func managementPanel(_ panel: ManagementPanelController, didRequestRenameLayout preset: LayoutPreset, to newName: String)
+    func managementPanelDidChangeHotkey(_ panel: ManagementPanelController)
 }
 
 // MARK: - ManagementPanelController

--- a/Sobani/ManagementPanelSettingsView.swift
+++ b/Sobani/ManagementPanelSettingsView.swift
@@ -25,13 +25,6 @@ final class ManagementPanelSettingsView: NSView {
     private static let popupX: CGFloat = 90
     private static let popupWidth: CGFloat = 180
     private static let hotkeyLabelX: CGFloat = 24
-    private static let hotkeyLabelWidth: CGFloat = 120
-    private static let hotkeyKeyLabelX: CGFloat = 150
-    private static let hotkeyKeyLabelWidth: CGFloat = 60
-    private static let hotkeyRecordButtonX: CGFloat = 215
-    private static let hotkeyResetButtonX: CGFloat = 275
-    private static let hotkeyButtonWidth: CGFloat = 56
-    private static let hotkeyButtonHeight: CGFloat = 22
     private static let resetAllButtonX: CGFloat = 24
     private static let resetAllButtonWidth: CGFloat = 100
     private static let resetAllButtonHeight: CGFloat = 24
@@ -49,7 +42,8 @@ final class ManagementPanelSettingsView: NSView {
     private var ghostAlphaPercentLabel: NSTextField?
     private var languagePopup: NSPopUpButton?
     private var themePopup: NSPopUpButton?
-    private var hotkeyKeyLabels: [HotkeyAction: NSTextField] = [:]
+    private var hotkeyRecorders: [HotkeyAction: HotkeyRecorderView] = [:]
+    private var resetAllHotkeysButton: NSButton?
 
     // MARK: - Init
 
@@ -215,60 +209,28 @@ final class ManagementPanelSettingsView: NSView {
 
         // [すべてリセット] ボタン (上から400)
         let resetAllY = totalHeight - 400 - Self.resetAllButtonHeight
-        let resetAllButton = NSButton(frame: NSRect(
+        let resetAllBtn = NSButton(frame: NSRect(
             x: Self.resetAllButtonX,
             y: resetAllY,
             width: Self.resetAllButtonWidth,
             height: Self.resetAllButtonHeight
         ))
-        resetAllButton.bezelStyle = .rounded
-        resetAllButton.title = L("management.reset_all_hotkeys")
-        resetAllButton.isEnabled = false
-        addSubview(resetAllButton)
+        resetAllBtn.bezelStyle = .rounded
+        resetAllBtn.title = L("management.reset_all_hotkeys")
+        resetAllBtn.target = self
+        resetAllBtn.action = #selector(resetAllHotkeysTapped)
+        addSubview(resetAllBtn)
+        resetAllHotkeysButton = resetAllBtn
     }
 
     private func setupHotkeyRow(action: HotkeyAction, y: CGFloat) {
-        // アクション名ラベル
-        let nameLabel = NSTextField(labelWithString: action.displayName)
-        nameLabel.frame = NSRect(x: Self.hotkeyLabelX, y: y, width: Self.hotkeyLabelWidth, height: Self.rowHeight)
-        nameLabel.font = .systemFont(ofSize: Self.labelFontSize)
-        addSubview(nameLabel)
-
-        // キー表示ラベル
-        let keyLabel = NSTextField(labelWithString: HotkeyManager.shared.binding(for: action).displayString)
-        keyLabel.frame = NSRect(x: Self.hotkeyKeyLabelX, y: y, width: Self.hotkeyKeyLabelWidth, height: Self.rowHeight)
-        keyLabel.font = .monospacedSystemFont(ofSize: Self.labelFontSize, weight: .regular)
-        keyLabel.alignment = .center
-        keyLabel.wantsLayer = true
-        keyLabel.layer?.cornerRadius = 4
-        keyLabel.layer?.borderWidth = 1
-        keyLabel.layer?.borderColor = NSColor.separatorColor.cgColor
-        addSubview(keyLabel)
-        hotkeyKeyLabels[action] = keyLabel
-
-        // [記録] ボタン (Phase 9で有効化)
-        let recordButton = NSButton(frame: NSRect(
-            x: Self.hotkeyRecordButtonX,
-            y: y + 2,
-            width: Self.hotkeyButtonWidth,
-            height: Self.hotkeyButtonHeight
-        ))
-        recordButton.bezelStyle = .rounded
-        recordButton.title = L("management.record")
-        recordButton.isEnabled = false
-        addSubview(recordButton)
-
-        // [リセット] ボタン (Phase 9で有効化)
-        let resetButton = NSButton(frame: NSRect(
-            x: Self.hotkeyResetButtonX,
-            y: y + 2,
-            width: Self.hotkeyButtonWidth,
-            height: Self.hotkeyButtonHeight
-        ))
-        resetButton.bezelStyle = .rounded
-        resetButton.title = L("management.reset")
-        resetButton.isEnabled = false
-        addSubview(resetButton)
+        let recorderFrame = NSRect(x: Self.hotkeyLabelX, y: y, width: 340, height: 24)
+        let recorder = HotkeyRecorderView(action: action, frame: recorderFrame)
+        recorder.onHotkeyChanged = { [weak self] act, binding in
+            self?.onHotkeyChanged?(act, binding)
+        }
+        addSubview(recorder)
+        hotkeyRecorders[action] = recorder
     }
 
     // MARK: - Helper Factories
@@ -328,7 +290,7 @@ final class ManagementPanelSettingsView: NSView {
 
         // ホットキー表示の更新
         for action in HotkeyAction.allCases {
-            hotkeyKeyLabels[action]?.stringValue = HotkeyManager.shared.binding(for: action).displayString
+            hotkeyRecorders[action]?.updateDisplay()
         }
     }
 
@@ -367,5 +329,16 @@ final class ManagementPanelSettingsView: NSView {
         guard idx >= 0, idx < AppTheme.allCases.count else { return }
         let theme = AppTheme.allCases[idx]
         AppThemeSettings.currentTheme = theme
+    }
+
+    @objc private func resetAllHotkeysTapped() {
+        HotkeyManager.shared.resetAllBindings()
+        for action in HotkeyAction.allCases {
+            hotkeyRecorders[action]?.updateDisplay()
+        }
+        // 全リセット後も onHotkeyChanged を通知（再登録のトリガー）
+        if let firstAction = HotkeyAction.allCases.first {
+            onHotkeyChanged?(firstAction, HotkeyManager.shared.binding(for: firstAction))
+        }
     }
 }


### PR DESCRIPTION
## 概要

- `HotkeyRecorderView`: キー記録UI（ESCキャンセル、修飾キー必須検証、システム/Sobani内衝突検出）
- 設定タブのホットキーセクションにレコーダーを統合、すべてリセットボタン有効化
- ホットキー変更時にイベントモニターを動的再登録（teardownAndRebuildHotkeyMonitors）

## テスト計画

- [x] `./build.sh` — SwiftLint含め正常ビルド
- [x] `xcodebuild test` — 全632テストパス

Closes #35