### PR TITLE
feat: 管理パネル Phase 10 — 双方向同期 + エッジケース

### DIFF
--- a/Sobani/AppDelegate+ManagementPanel.swift
+++ b/Sobani/AppDelegate+ManagementPanel.swift
@@ -13,8 +13,10 @@ extension AppDelegate {
         switch action {
         case .toggleVisibility:
             toggleAllWindowsVisibility()
+            managementPanelController?.reloadWindowList()
         case .toggleGhostMode:
             toggleAllGhostMode()
+            managementPanelController?.reloadWindowList()
         case .managementPanel:
             managementPanelController?.toggle()
         }
@@ -110,5 +112,9 @@ extension AppDelegate: ManagementPanelDelegate {
 
     func managementPanelDidChangeHotkey(_ panel: ManagementPanelController) {
         teardownAndRebuildHotkeyMonitors()
+    }
+
+    func managementPanelDidDismiss(_ panel: ManagementPanelController) {
+        quitIfNoWindows()
     }
 }

--- a/Sobani/AppDelegate.swift
+++ b/Sobani/AppDelegate.swift
@@ -217,7 +217,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     func quitIfNoWindows() {
-        if Self.shouldQuitApp(windowCount: zOrderedWindows.count, isApplyingLayout: isApplyingLayout) {
+        if Self.shouldQuitApp(windowCount: zOrderedWindows.count, isApplyingLayout: isApplyingLayout)
+            && !(managementPanelController?.isVisible ?? false) {
             shouldTerminate = true
             NSApp.terminate(nil)
         }
@@ -260,6 +261,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         charWindow.windowId = nextWindowId
         nextWindowId += 1
         addCharacterWindow(charWindow)
+        managementPanelController?.reloadWindowList()
     }
 
     @objc func addNewWindowWithNewImageFromMenu() {
@@ -319,6 +321,7 @@ extension AppDelegate: CharacterWindowDelegate {
         if zOrderedWindows.isEmpty {
             areWindowsHidden = false
         }
+        managementPanelController?.reloadWindowList()
         quitIfNoWindows()
     }
 
@@ -327,9 +330,7 @@ extension AppDelegate: CharacterWindowDelegate {
     }
 
     func characterWindowDidChangeHidden(_ sender: CharacterWindow) {
-        // Intentionally empty: status bar menu rebuilds its content
-        // each time it opens (in buildStatusBarMenu), so no immediate
-        // update is needed here.
+        managementPanelController?.reloadWindowList()
     }
 
     func characterWindowDidDeleteImage(named name: String) {

--- a/Sobani/ManagementPanelController.swift
+++ b/Sobani/ManagementPanelController.swift
@@ -21,6 +21,7 @@ protocol ManagementPanelDelegate: AnyObject {
     func managementPanel(_ panel: ManagementPanelController, didRequestDeleteLayout preset: LayoutPreset)
     func managementPanel(_ panel: ManagementPanelController, didRequestRenameLayout preset: LayoutPreset, to newName: String)
     func managementPanelDidChangeHotkey(_ panel: ManagementPanelController)
+    func managementPanelDidDismiss(_ panel: ManagementPanelController)
 }
 
 // MARK: - ManagementPanelController
@@ -116,6 +117,7 @@ final class ManagementPanelController: NSObject {
     func dismiss() {
         clearEventMonitors()
         panel?.orderOut(nil)
+        delegate?.managementPanelDidDismiss(self)
     }
 
     // MARK: - Panel Setup


### PR DESCRIPTION
## 概要

- ウィンドウ追加/削除/表示変更時にパネルリストを自動更新
- Option+H/G 操作後もリスト更新
- パネル表示中は `quitIfNoWindows` でアプリ終了しないガード追加
- パネル閉時に `quitIfNoWindows` を再評価（`managementPanelDidDismiss`）

## テスト計画

- [x] `./build.sh` — SwiftLint含め正常ビルド
- [x] `xcodebuild test` — 全632テストパス

Closes #36